### PR TITLE
Enable Dependabot for GitHub Actions [changelog skip]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
-    open-pull-requests-limit: 1 # Limit concurrent CI runs from executing
     schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates#supported-repositories-and-ecosystems

I've also:
* Changed the frequency to daily, so we don't have to wait as long.
* Removed the concurrent PRs limit (since now this repo is under the `heroku` org, the Circle CI concurrency limits are a non-issue).
* Removed the `labels` config which causes the default to be used, which (a) does the same but more (adds lang specific labels), but also auto-creates the labels, which fixed the errors seen in #49 etc.

Refs GUS-W-9678950.