### PR TITLE
Make Check Changelog skip Dependabot PRs

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -11,7 +11,8 @@ jobs:
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
       !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Check that CHANGELOG is touched


### PR DESCRIPTION
So we don't have to add the `skip changelog` label each time, and for parity with all of our other repos.

This is identical to forcedotcom/sf-fx-runtime-nodejs#191.