### PR TITLE
Remove unused `.env` file

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,17 +12,6 @@ ruby_version = "2.6.6"
   ]
 
   [[publish.Vendor]]
-  # get tokens for logging build tokens
-  url = "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz"
-  dir = "."
-  files = ["./.env"]
-  [[publish.Vendor]]
-  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar-14/ruby-2.6.6.tgz"
-  dir = "vendor/ruby/cedar-14"
-  [[publish.Vendor]]
-  url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-16/ruby-2.6.6.tgz"
-  dir = "vendor/ruby/heroku-16"
-  [[publish.Vendor]]
   url = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.6.6.tgz"
   dir = "vendor/ruby/heroku-18"
   [[publish.Vendor]]


### PR DESCRIPTION
This `.env` file is no longer used. It was copied over from the legacy buildpack. In addition we no longer support `cedar-14` or `heroku-16`.

GUS-W-8216066