### PR TITLE
Fix pack tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
   pack_cnb: &pack_cnb
     run:
       name: Run test suite
-      command: PARALLEL_SPLIT_TEST_PROCESSES="4" IS_RUNNING_ON_CI=1 bundle exec parallel_split_test spec/cnb
+      command: bundle exec rspec spec/cnb
   docker_commands: &docker_commands
     run:
       name: Run test suite

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ repos/*
 
 *.gem
 *.gemspec
+vendor/
+target/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       excon (>= 0.47.0)
       multi_json
     erubis (2.7.0)
-    excon (0.87.0)
+    excon (0.88.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
@@ -61,4 +61,4 @@ DEPENDENCIES
   stackprof
 
 BUNDLED WITH
-   2.2.25
+   2.2.30

--- a/bin/detect
+++ b/bin/detect
@@ -9,10 +9,8 @@ if [ -z "$CNB_STACK_ID" ]; then
   APP_DIR=$1
 
   if [ ! -f "$APP_DIR/Gemfile" ]; then
-    echo "no"
     exit 1
   else
-    echo "ruby"
     exit 0
   fi
 fi
@@ -24,7 +22,6 @@ APP_DIR=$(pwd)
 BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 
 if [ ! -f "$APP_DIR/Gemfile" ]; then
-  echo "no"
   exit 1
 else
   echo "Ruby"

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -70,7 +70,13 @@ EOF
 download_ruby_version_to_buildpack_vendor()
 {
   local ruby_version=$1
-  heroku_buildpack_ruby_dir="$BUILDPACK_DIR/vendor/ruby/$STACK"
+  download_ruby_version_to_dir "$ruby_version" "$BUILDPACK_DIR/vendor/ruby/$STACK"
+}
+
+download_ruby_version_to_dir()
+{
+  local ruby_version=$1
+  local heroku_buildpack_ruby_dir=$2
 
   # The -d flag checks to see if a file exists and is a directory.
   # This directory may be non-empty if a previous compile has

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+source "$SCRIPT_DIR/bin/support/bash_functions.sh"
+BUILDPACK_DIR="$SCRIPT_DIR"
+
+STACK="heroku-18"
+bootstrap_ruby_to_buildpack_dir
+
+STACK="heroku-20"
+bootstrap_ruby_to_buildpack_dir
+
+targetdir="$SCRIPT_DIR/target"
+
+if [ -d "$targetdir" ]; then
+    rm -rf "$targetdir"
+fi
+mkdir "$targetdir"
+
+# Point target dir at current dir
+# Can't use a symlink because 🤷🏻‍♂️
+# https://superuser.com/a/180653
+TARGETDIR='target';for file in *;do test "$file" != "$TARGETDIR" && cp -r "$file" "$TARGETDIR/";done

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,8 +1,8 @@
-api = "0.2"
+api = "0.4"
 
 [buildpack]
 id = "heroku/ruby"
-version = "0.0.1"
+version = "1.0.2"
 name = "Ruby"
 ruby_version = "2.6.6"
 
@@ -31,3 +31,6 @@ ruby_version = "2.6.6"
 
 [[stacks]]
 id = "heroku-18"
+
+[[stacks]]
+id = "heroku-20"

--- a/package.toml
+++ b/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "."

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,16 +23,17 @@ def hatchet_path(path = "")
   Pathname(__FILE__).join("../../repos").expand_path.join(path)
 end
 
+RUBY_BUILDPACK = Cutlass::LocalBuildpack.new(directory: Pathname(__dir__).join(".."))
+
 Cutlass.config do |config|
-  # Image pinned to fix CI until https://github.com/heroku/buildpacks-ruby/pull/79 lands. 
-  config.default_builder = "heroku/buildpacks:18@sha256:7590c0bc92e574253e44ef3848579869cfeb610b80de093463ef4a7d8de3ae03"
+  config.default_builder = "heroku/buildpacks:20"
 
   # Where do your test fixtures live?
   config.default_repo_dirs = [hatchet_path("ruby_apps")]
 
   # Where does your buildpack live?
   # Can be a directory or a Cutlass:LocalBuildpack instance
-  config.default_buildpack_paths = [Pathname(__dir__).join("..")]
+  config.default_buildpack_paths = [RUBY_BUILDPACK]
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
The Ruby buildpack needs a Ruby binary to "bootstrap" its own execution. With v2 this is done at release time and when being used via git dynamically in `bin/compile`.

That same behavior was ported over to this buildpack, however the directory we write to cannot be in the same directory as the buildpack itself. This causes an error:

```
      [INFO] Discovering process types
       [INFO] Procfile declares types -> web
       ERROR: failed to build: exit status 1

       stderr: mkdir: cannot create directory '/cnb/buildpacks/heroku_ruby/0.0.1/vendor/ruby': Permission denied
       ERROR: failed to build: executing lifecycle: failed with status code: 145
```

## Why didn't this break before

Described in buildpacks/pack#1322 the only reason builds were previously working is that another image using the Ruby identifier and the same version were previously installed and they had the files we needed.

## Test Fix

This PR changes moves the behavior of copying binaries out of `bin/compile` for the CNB interface and instead into the `build.sh` interface which the Cutlass testing tool understands https://github.com/heroku/cutlass/.

When cutlass calls `build.sh` it will vendor in the appropriate binaries (if they don't already exist) and then copy everything to the `target` directory.

## Deploy fix

The same process needs to happen before buildpacks are deployed. This buildpack is currently not deployed, only the "legacy" buildpack is github.com/heroku/heroku-buildpack-ruby.

For the v2 deploy process the `publish.Vendor` in the `buildpack.toml` is understood by Heroku's platform/deploy-process.

For CNB, I'm honestly not sure how those files are getting vendored. It actually looks like they're not:

```
$ cd /tmp
$ cat Dockerfile
FROM alpine:3 AS base

FROM public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack:0.1.3 as buildpack
COPY --from=base / /
```

Then:

```
$ docker build -t inspectbuildpack .
$ docker run -it --rm inspectbuildpack sh
~$ ls cnb/buildpacks/heroku_ruby/0.1.3/vendor/
dotenv.rb     lpxc.rb       syck_hack.rb  toml.rb
```

I'm not sure how this is working unless people are using it without pack and it's manually downloading the binaries every time.

Doing the same trick with `0.1.0` it looks like it's never been vendored:

```
/ # ls cnb/buildpacks/heroku_ruby/0.1.0/vendor/
dotenv.rb     lpxc.rb       syck_hack.rb  toml.rb
```