### PR TITLE
Temporarily pin builder version to fix CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,8 @@ def hatchet_path(path = "")
 end
 
 Cutlass.config do |config|
-  config.default_builder = "heroku/buildpacks:18"
+  # Image pinned to fix CI until https://github.com/heroku/buildpacks-ruby/pull/79 lands. 
+  config.default_builder = "heroku/buildpacks:18@sha256:7590c0bc92e574253e44ef3848579869cfeb610b80de093463ef4a7d8de3ae03"
 
   # Where do your test fixtures live?
   config.default_repo_dirs = [hatchet_path("ruby_apps")]


### PR DESCRIPTION
Pins the builder version until a more complete fix lands in #79, so I can merge #76.

See #79 and:
https://heroku.slack.com/archives/C01R6FJ738U/p1636658489053400?thread_ts=1636650731.042300&cid=C01R6FJ738U