### PR TITLE
Convert heroku/buildpacks-ruby to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,99 @@
+name: heroku/buildpacks-ruby/build
+on:
+  push:
+env:
+  HATCHET_APP_LIMIT: xxxxxxx
+  HATCHET_EXPENSIVE_MODE: xxxxxxx
+  HATCHET_RETRIES: xxxxxxx
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+  IS_RUNNING_ON_CI: xxxxxxx
+jobs:
+  shellcheck:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ubuntu
+    steps:
+    - uses: actions/checkout@v2
+#     # This item has no matching transformer
+#     - circleci_shellcheck_install:
+    - name: Check build,compile,detect,release and bash_functions.sh with shellcheck
+      run: shellcheck -x bin/build bin/compile bin/detect bin/release bin/support/bash_functions.sh
+  unit:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    steps:
+    - name: Set up bundler cache
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+        bundler-cache: true
+    - uses: actions/checkout@v2
+    - run: bundle check || bundle install
+      env:
+        BUNDLE_DEPLOYMENT: true
+    - name: Hatchet setup
+      run: bundle exec hatchet ci:setup
+    - name: Run test suite
+      run: PARALLEL_SPLIT_TEST_PROCESSES="4" IS_RUNNING_ON_CI=1 bundle exec parallel_split_test spec/unit
+  hatchet:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    steps:
+    - name: Set up bundler cache
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+        bundler-cache: true
+    - uses: actions/checkout@v2
+    - run: bundle check || bundle install
+      env:
+        BUNDLE_DEPLOYMENT: true
+    - name: Hatchet setup
+      run: bundle exec hatchet ci:setup
+    - name: Run test suite
+      run: PARALLEL_SPLIT_TEST_PROCESSES=25 IS_RUNNING_ON_CI=1 bundle exec parallel_split_test spec/hatchet
+  pack_cnb:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    steps:
+    - name: Set up bundler cache
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+        bundler-cache: true
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+#     # This item has no matching transformer
+#     - buildpacks_pack_install_pack:
+    - run: bundle check || bundle install
+      env:
+        BUNDLE_DEPLOYMENT: true
+    - name: Hatchet setup
+      run: bundle exec hatchet ci:setup
+    - name: Run test suite
+      run: bundle exec rspec spec/cnb
+  docker_commands:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    steps:
+    - name: Set up bundler cache
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.2
+        bundler-cache: true
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+#     # This item has no matching transformer
+#     - buildpacks_pack_install_pack:
+    - run: bundle check || bundle install
+      env:
+        BUNDLE_DEPLOYMENT: true
+    - name: Hatchet setup
+      run: bundle exec hatchet ci:setup
+    - name: Run test suite
+      run: PARALLEL_SPLIT_TEST_PROCESSES="4" IS_RUNNING_ON_CI=1 bundle exec parallel_split_test spec/docker


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/buildpacks-ruby) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/buildpacks-ruby/build
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest
- [ ] Ensure: The correct Ruby version is added to all ruby/setup-ruby actions. A placeholder corresponding to the latest stable ruby version has been set automatically.