### PR TITLE
Use formatdoc! instead of format! in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
+
+## [2.0.0] 2023/31/01
 
 - Initial version of Ruby buildpack in Rust (https://github.com/heroku/buildpacks-ruby/pull/93)
+- Version 2.0.0 for the first release is not a typo. There was an issue in pack where a builder with the same name and version number would reuse artifacts left on image from [prior runs which caused issues](https://github.com/buildpacks/pack/issues/1322#issuecomment-1038241038). There were prior releases of `heroku/ruby` CNB from different sources that triggered this problem. To ensure no one would encounter that issue we developed and released using a version we know has not been used before. Version 2.0 was the first major version without a prior release of `heroku/ruby` CNB from any source.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,37 @@ This buildpack is a Cloud Native Buildpack (CNB). CNB is a specification for bui
 
 You can find out more about the CNB project at https://buildpacks.io/.
 
+## Use `heroku/ruby` CNB locally with `pack`
+
+To use the currently deployed `heroku/ruby` buildpack locally, you'll need a copy of `pack` installed. On a mac you can run:
+
+```
+$ brew install pack
+```
+
+You'll also need to run [docker desktop](https://www.docker.com/products/docker-desktop/). With docker running, run the buildpack against a Ruby application by running:
+
+```
+$ pack build <image-name-to-build> --builder heroku/builder:22 --path <path-to-ruby-app>
+```
+
+For example:
+
+```
+$ cd /tmp
+$ git clone https://github.com/heroku/ruby-getting-started
+$ cd ruby-getting-started
+$ pack build my-image --builder heroku/builder:22 --path ./ruby-getting-started
+===> ANALYZING
+Previous image with name "my-image" not found
+===> DETECTING
+# ...
+```
+
+The buildpack is released to Heroku's [heroku/builder images](https://github.com/heroku/builder). This buildpack is currently released on:
+
+- `heroku/builder:22`
+
 ## Application contract
 
 The sections below describe the expected behavior of the buildpack. The codebase must be updated if a difference exists between this contract and actual behavior. Either the code needs to change to suit the contract, or the contract needs to be updated. If you see a difference, please open an issue with a [minimal application that reproduces the problem](https://www.codetriage.com/example_app).
@@ -26,7 +57,7 @@ If you need application-specific support, you can ask on an official Heroku supp
 
 ### Application Contract: Detect
 
-The detect phase determine whether or not this buildpack can execute. It can also be used to request additional functionality via "requiring" behavior from other buildpacks.
+The detect phase determines whether or not this buildpack can execute. It can also be used to request additional functionality via requiring behavior from other buildpacks.
 
 - Node version
   - Given a `package.json` file in the root of the application the `heroku/nodejs-engine` buildpack will be required. [See README for behavior](https://github.com/heroku/buildpacks-nodejs/tree/main/buildpacks/nodejs-engine)
@@ -41,58 +72,61 @@ The detect phase determine whether or not this buildpack can execute. It can als
 
 Once an application has passed the detect phase, the build phase will execute to prepare the application to run.
 
-- Ruby version
-  - Given a `Gemfile.lock` with an explicit Ruby version we will install that Ruby version.
-  - Given a `Gemfile.lock` without an explicit Ruby version we will install a default Ruby version.
-    - When the default value changes, applications without an explicit Ruby version will receive the updated default Ruby version on their next deployment.
-  - We will reinstall Ruby if your stack changes.
-- Bundler version
+- Ruby version:
+  - Given a `Gemfile.lock` with an explicit Ruby version, we will install that Ruby version.
+  - Given a `Gemfile.lock` without an explicit Ruby version, we will install a default Ruby version.
+    - When the default value changes, applications without an explicit Ruby version will receive the updated version on their next deployment.
+  - We will reinstall Ruby if your stack (operating system) changes.
+- Bundler version:
   - Given a `Gemfile.lock` with an explicit Bundler version we will install that bundler version.
   - Given a `Gemfile.lock` without an explicit Bundler version we will install a default Ruby version.
-- Ruby Dependencies
+- Ruby Dependencies:
   - We MAY install gem dependencies using `bundle install`
-    - We will always run `bundle install` for the first build
+    - We will always run `bundle install` for the first build.
     - We will sometimes run this command again if we detect one of the following has changed:
-      - Gemfile
-      - Gemfile.lock
-      - User configurable environment variables
-    - [TODO] To ensure that `bundle install` is run on every build set `HEROKU_SKIP_BUNDLE_DIGEST=1`
-  - We will run `bundle clean` after a successful `bundle install` via setting `BUNDLE_CLEAN=1` environment variable.
-  - We will cache the contents of your gem dependencies.
-      - We will invalidate the dependency cache if your stack changes.
-      - We will invalidate the dependency cache if your Ruby version changes.
+      - `Gemfile`
+      - `Gemfile.lock`
+      - User configurable environment variables.
+    -To always run `bundle install` even if there are changes if the environment variable `HEROKU_SKIP_BUNDLE_DIGEST=1` is found.
+  - We will always run `bundle clean` after a successful `bundle install` via setting `BUNDLE_CLEAN=1` environment variable.
+  - We will always cache the contents of your gem dependencies.
+      - We will always invalidate the dependency cache if your stack (operating system) changes.
+      - We will always invalidate the dependency cache if your Ruby version changes.
       - We may invalidate the dependency cache if there was a bug in a prior buildpack version that needs to be fixed.
 - Gem specific behavior - We will parse your `Gemfile.lock` to determine what dependencies your app need for use in specializing your install behavior (i.e. Rails 5 versus Rails 4). The inclusion of these gems may trigger different behavior:
   - `railties`
 - Applications without `rake` in the `Gemfile.lock` or a `Rakefile` variant MAY skip rake task detection.
 - Rake execution - We will determine what rake tasks are runnable via the output of `rake -P` against your application.
-  - We WILL abort the build if the `rake -p` task fails.
-  - We will run `rake assets:precompile` on your app if that task exists on your application.
-    - We will skip this `assets:precompile` task if a manifest file exists in the `public/assets` folder that indicates precompiled assets are checked into git.
-      - ".sprockets-manifest-*.json"
-      - "manifest-*.json"
-    - We will abort your build if the `rake assets:precompile` task fails
-    - We will run `rake assets:clean` on your app. (Reference: https://github.com/heroku/buildpacks-ruby/blob/d526a49f81becaf571329a1adf5fff0668a6b99a/lib/heroku_buildpack_ruby/assets_precompile.rb#L67-L73, reference: https://github.com/heroku/heroku-buildpack-ruby/blob/951fc728979695990c32df2d4d60ae2d6f6f61c2/lib/language_pack/rails4.rb#L83-L94)
-      - We will cache the contents of `public/assets` if `assets:clean` exists on your application. (pending https://github.com/buildpacks/spec/blob/main/buildpack.md#slice-layers support in libcnbrs)
-      - We will cache asset "fragments" directories if the `assets:clean` exists on the system. (pending https://github.com/buildpacks/spec/blob/main/buildpack.md#slice-layers support in libcnbrs)
-        - We will limit or prune the size of the asset cache in `tmp/cache/assets` to 100 MiB.
-- Process types
-  - Given an application with the `railties` gem we will run `bin/rails server` while specifying `-p $PORT` and `-e $RAILS_ENV"` by default as the `web` process. Use the `Procfile` to override.
-  - If the `railties` gem is not present we will run `rackup` while specifying `-p $PORT` and `-h 0.0.0.0` by default as the `web` process. Use the `Procfile` to override. This requires the `rack` gem and a `config.ru` file.
+  - We will always abort the build if the `rake -p` task fails.
+  - We will always run `rake assets:precompile` on your app if that task exists for your application.
+    - We will always skip this `assets:precompile` task if a manifest file exists in the `public/assets` folder that indicates precompiled assets are checked into git.
+      - `.sprockets-manifest-*.json`
+      - `manifest-*.json`
+    - We will abort your build if the `rake assets:precompile` task fails.
+    - We will run `rake assets:clean` on your app.
+      - We will cache the contents of `public/assets` if `assets:clean` exists on your application.
+      - We will cache asset "fragments" directories if the `assets:clean` exists on the system.
+      - We will limit or prune the size of the asset cache in `tmp/cache/assets` to 100 MiB.
+        - We will delete the least recently used (LRU) files first. Detected via file mtime.
+- Process types:
+  - Given an application with the `railties` gem:
+    - We will default the web process to `bin/rails server` while specifying `-p $PORT` and `-e $RAILS_ENV"`. Use the `Procfile` to override this default.
+  - If `railties` gem is not found but `rack` gem is present and a `config.ru` file exists on root:
+    - We will default the web process to `rackup` while specifying `-p $PORT` and `-h 0.0.0.0`. Use the `Procfile` to override this default. .
 - Environment variable defaults - We will set a default for the following environment variables:
-  - `JRUBY_OPTS="-Xcompile.invokedynamic=false"` - Invoke dynamic is a feature of the JVM intended to enhance support for dynamicaly typed languages (such as Ruby). This caused issues with Physion Passenger 4.0.16 and was disabled [details](https://github.com/heroku/heroku-buildpack-ruby/issues/145).
-  - `RACK_ENV=${RACK_ENV:-"production"}` - An environment variable that may affect the behavior of Rack based webservers and webapps.
-  - `RAILS_ENV=${RAILS_ENV:-"production"}` - A value used by all Rails apps. By default Rails ships with three environments: `development`, `test,` and `production`. We recommend all apps being deployed to use `production` and recommend against using a custom env such as `staging` [details](https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment).
-  - `SECRET_KEY_BASE=${SECRET_KEY_BASE:-<generate a secret key>}` - In Rails 4.1+ apps a value is needed to generate cryptographic tokens used for a variety of things. Notably this value is used in generating user sessions so modifying it between builds will have the effect of logging out all users. Heroku provides a default generated value.
+  - `JRUBY_OPTS="-Xcompile.invokedynamic=false"` - Invoke dynamic is a feature of the JVM intended to enhance support for dynamicaly typed languages (such as Ruby). This caused issues with Physion Passenger 4.0.16 and was disabled [details](https://github.com/heroku/heroku-buildpack-ruby/issues/145). You can override this value.
+  - `RACK_ENV=${RACK_ENV:-"production"}` - An environment variable that may affect the behavior of Rack based webservers and webapps. You can override this value.
+  - `RAILS_ENV=${RAILS_ENV:-"production"}` - A value used by all Rails apps. By default, Rails ships with three environments: `development`, `test,` and `production`. We recommend all apps being deployed to use `production` and recommend against using a custom env such as `staging` [details](https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment). You can override this value.
+  - `SECRET_KEY_BASE=${SECRET_KEY_BASE:-<generate a secret key>}` - In Rails 4.1+ apps a value is needed to generate cryptographic tokens used for a variety of things. Notably this value is used in generating user sessions so modifying it between builds will have the effect of logging out all users. This buildpack provides a default generated value. You can override this value.
+  - `BUNDLE_WITHOUT=development:test` - Tells bundler to not install `development` or `test` groups during `bundle install`. You can override this value.
 - Environment variables modified - In addition to the default list this is a list of environment variables that the buildpack modifies:
   - `BUNDLE_BIN=<bundle-path-dir>/bin` - Install executables for all gems into specified path.
-  - `BUNDLE_CLEAN=1` - After successful `bundle install` bundler will automatically run `bundle clean`.
-  - `BUNDLE_DEPLOYMENT=1` - Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
+  - `BUNDLE_CLEAN=1` - After successful `bundle install` bundler will automatically run `bundle clean` to remove all stale gems from previous builds that are no longer specified in the `Gemfile.lock`.
+  - `BUNDLE_DEPLOYMENT=1` - Requires `Gemfile.lock` to be in sync with the current `Gemfile`.
   - `BUNDLE_GEMFILE=<app-dir>/Gemfile` - Tells bundler where to find the `Gemfile`.
   - `BUNDLE_PATH=<bundle-path-dir>` - Directs bundler to install gems to this path
-  - `BUNDLE_WITHOUT=development:test:$BUNDLE_WITHOUT` - Do not install `development` or `test` groups via bundle install. Additional groups can be specified via user config.
   - `DISABLE_SPRING="1"` - Spring is a library that attempts to cache application state by forking and manipulating processes with the goal of decreasing development boot time. Disabling it in production removes significant problems [details](https://devcenter.heroku.com/changelog-items/1826).
-  - `GEM_PATH=<bundle-path-dir>` - Tells Ruby where gems are located
+  - `GEM_PATH=<bundle-path-dir>` - Tells Ruby where gems are located.
   - `MALLOC_ARENA_MAX=2` - Controls glibc memory allocation behavior with the goal of decreasing overall memory allocated by Ruby [details](https://devcenter.heroku.com/changelog-items/1683).
   - `PATH` - Various executables are installed and the `PATH` env var will be modified so they can be executed at the system level. This is mostly done via interfaces provided by `libcnb` and CNB layers rather than directly.
   - `RAILS_LOG_TO_STDOUT="enabled"` - Sets the default logging target to STDOUT for Rails 5+ apps. [details](https://blog.heroku.com/container_ready_rails_5)
@@ -100,7 +134,7 @@ Once an application has passed the detect phase, the build phase will execute to
 
 ### Next-gen application contract
 
-These are tracked things the buildpack will eventually do in the application contract but are not currently priorities.
+These are tracked things the buildpack will eventually do in the application contract but are not currently implemented.
 
 - [TODO] Warn on invalid Ruby binstub (https://github.com/heroku/heroku-buildpack-ruby/blob/main/lib/language_pack/helpers/binstub_wrapper.rb, and https://github.com/heroku/heroku-buildpack-ruby/blob/main/lib/language_pack/helpers/binstub_check.rb)
 - [TODO] Warn on default ruby version (https://github.com/heroku/heroku-buildpack-ruby/blob/26065614274ed1138620806c9a8d705e39b4412c/lib/language_pack/ruby.rb#L532)
@@ -131,14 +165,13 @@ end
 
 ### Known differences against `heroku/heroku-buildpack-ruby`
 
-This buildpack does not port all behaviors of the [original buildpack for Ruby ](https://github.com/heroku/heroku-buildpack-ruby). This buildpack is also known as "classic". This section outlines the known behaviors where the two buildpacks diverge.
+This buildpack does not port all behaviors of the [original buildpack for Ruby ](https://github.com/heroku/heroku-buildpack-ruby), which is also known as "classic". This section outlines the known behaviors where the two buildpacks diverge.
 
-- Rails 5+ support only. The v2 buildpack supports Rails 2+. There are significant maintenance gains for buildpack authors [starting in Rails 5](https://blog.heroku.com/container_ready_rails_5) which was released in 2016. In an effort to reduce overall internal complexity this buildpack does not explicitly support Rails before version 5.
+- Rails 5+ support only. The classic buildpack supports Rails 2+. There are significant maintenance gains for buildpack authors [starting in Rails 5](https://blog.heroku.com/container_ready_rails_5) which was released in 2016. In an effort to reduce overall internal complexity this buildpack does not explicitly support Rails before version 5.
 - Rails support is now based on the above application contract. Previously there was no official policy for dropping support for older Rails versions. Support was based on whether or not an older version could run on a currently supported Ruby version. With [Rails LTS](https://railslts.com/) this can mean a very old version of Rails. Now we will actively support Rails versions currently [under the Rails core maintenance policy](https://guides.rubyonrails.org/maintenance_policy.html) provided those versions can run on a supported Ruby version. As Rails versions go out of official maintenance compatibility features may be removed with no supported replacement.
-- Default Ruby versions are no longer sticky. Before bundler started recording the Ruby version in the `Gemfile.lock` it was common for developers to forget to declare their Ruby version in their `Gemfile`. When that happens they would receive the default Ruby version. To guard against instability we would record that version and use it on future deploys. Now it's less likely for an app to deploy without a default ruby version, and we do not want to encourage relying on a default for stability (as this otherwise breaks dev-prod parity).
-- Ruby versions come from the `Gemfile.lock` only. Before bundler started recording the Ruby version in the `Gemfile.lock`, Heroku would pull the Ruby version via running `bundle platform --ruby` to pull any ruby declaration such as `ruby "3.1.2"` from the `Gemfile`. This creates a bootstrapping problem, because you need a version of Ruby to run `bundle platform` to find the version of Ruby the application needs. Since the Ruby version is now recorded in the `Gemfile.lock`, this extra bootstrapping problem is less needed and applications should rely on their version being in their `Gemfile.lock` instead.
-- Bundler version is now based on `Gemfile.lock`. Previously there was a known good version of bundler on the system for Bundler 1.x and Bundler 2.x. With Bundler 2.3+ a feature was added for Bundler to re-exec itself when it found that it was being run with a different version. Also backwards incompatible features were added in patch versions which forced us to upgrade bundler versions for everyone, even when they were less stable. With the new model, you'll get the same version of bundler in production as you use in development. Whatever version is in the `Gemfile.lock` will be installed on the system. The biggest problem users may encounter is that locally they do not install with `BUNDLE_DEPLOYMENT=true` on which raises some edge cases. Developers are not responsible for ensuring their version of bundler is stable and not the cause for their build issue or failure.
-- Failure to detect rake tasks will fail a deployment. On all builds `rake -p` is called to find a list of all rake tasks. If this detection task fails then the previous behavior was to fail the build only if the `sprockets` gem was present. The reason was to allow API only apps that don't need to generate assets to have a `Rakefile` that cannot be run in production (the most common reason is they're requiring a library not in their production gemfile group). Now all failure to load a Rakefile will fail. If you want the old behavior you can [TODO](TODO-never-fail-rake). The reason for this change is it's more common that applications will want their builds to fail even if they're not using `sprockets`. It's also just not a good idea to not have your `Rakefile` not runable in production, we shouldn't encourage that pattern.
+- Ruby versions come from the `Gemfile.lock` only. Before bundler started recording the Ruby version in the `Gemfile.lock`, Heroku would pull the Ruby version via running `bundle platform --ruby` to pull any ruby declaration such as `ruby "3.1.2"` from the `Gemfile`. This creates a bootstrapping problem, because you need a version of Ruby to run `bundle platform` to find the version of Ruby the application needs. Since the Ruby version is now recorded in the `Gemfile.lock`, this extra bootstrapping problem is less needed and applications should rely on their version being in their `Gemfile.lock` instead. To update the Ruby version in `Gemfile.lock` run `bundle update --ruby`.
+- Default Ruby versions are no longer sticky. Before bundler started recording the Ruby version in the `Gemfile.lock` it was common for developers to forget to declare their Ruby version in their project. When that happens they would receive the default Ruby version from the classic buildpack. To guard against instability the classic buildpack would record that version and use it again on all future deploys where no explicit version was specified. Now it's less likely for an app to deploy without a ruby version in their `Gemfile.lock`, and we do not want to encourage relying on a default for stability (as this otherwise breaks dev-prod parity).
+- Failure to detect rake tasks will fail a deployment. On all builds `rake -p` is called to find a list of all rake tasks. If this detection task fails then the previous behavior was to fail the build only if the `sprockets` gem was present. The reason was to allow API-only apps that don't need to generate assets to have a `Rakefile` that cannot be run in production (the most common reason is they're requiring a library not in their production gemfile group). Now all failures when loading a `Rakefile` will fail the build. If you want the old behavior you can [TODO](TODO-never-fail-rake). The reason for this change is that it's more common that applications will want their builds to fail even if they're not using `sprockets`. It's also just not a good idea to not have your `Rakefile` not runable in production, we shouldn't encourage that pattern.
 - Caching of `public/assets` is gated on the presence of `rake assets:clean`. Previously this behavior was gated on the existence of a certain version of the Rails framework.
 - Caching of `tmp/cache/assets` (fragments) is gated on the presence of `rake assets:clean`. Previously this behavior was gated on the existence of a certain version of the Rails framework.
 
@@ -150,10 +183,16 @@ This buildpack does not port all behaviors of the [original buildpack for Ruby ]
 
 ### Compile the buildpack
 
-- Run:
+To build a debug release (faster to compile) run:
 
 ```
-cd buildpacks/ruby && cargo libcnb package ; cd -
+$(set -pipefail; cd buildpacks/ruby && cargo libcnb package; cd -)
+```
+
+To build a production release (faster to run, slower to compile) run this command:
+
+```
+$(set -pipefail; cd buildpacks/ruby && cargo libcnb package --release; cd -)
 ```
 
 ### Use that compiled buildpack on an application
@@ -164,12 +203,10 @@ To build the application vendored in `buildpacks/ruby/tests/fixtures/default_rub
 pack build my-image --buildpack target/buildpack/debug/heroku_ruby --path buildpacks/ruby/tests/fixtures/default_ruby --verbose
 ```
 
-The deployed buildpack ships with a builder that tells the `pack` CLI what other builpacks it needs. In development you must specify them via the `--buildpack` flag before this buildpack.
-
-For example to build an app that needs nodejs:
+The deployed buildpack ships with a builder that tells the `pack` CLI what other builpacks it needs. In development you must specify them via the `--buildpack` flag before this buildpack. For example to build an app that needs nodejs can run like this:
 
 ```
-pack build my-image  --buildpack heroku/nodejs-engine --buildpack heroku/procfile  --buildpack target/buildpack/debug/heroku_ruby --path <path/to/application> --verbose
+pack build my-image --buildpack heroku/nodejs-engine --buildpack heroku/procfile --buildpack target/buildpack/debug/heroku_ruby --path <path/to/application> --verbose
 ```
 
 List of buildpacks this buildpack depends on:

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -28,7 +28,7 @@ fn log_our_error(error: RubyBuildpackError) {
     match error {
         RubyBuildpackError::RakeDetectError(error) => user::log_error(
             "Error detecting rake tasks",
-            format! {"
+            formatdoc! {"
             The Ruby buildpack uses rake task information from your application to guide
             build logic. Without this information, the Ruby buildpack cannot continue.
 
@@ -40,7 +40,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::GemListGetError(error) => user::log_error(
             "Error detecting dependencies",
-            format! {"
+            formatdoc! {"
             The Ruby buildpack uses dependency information from your application to
             guide build logic. Without this information, the Ruby buildpack cannot
             continue.
@@ -52,7 +52,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::RubyInstallError(error) => user::log_error(
             "Error installing Ruby",
-            format! {"
+            formatdoc! {"
             Could not install the detected Ruby version.
 
             Details:
@@ -62,7 +62,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::MissingGemfileLock(error) => user::log_error(
             "Error: Gemfile.lock required",
-            format! {"
+            formatdoc! {"
             To deploy a Ruby application, a Gemfile.lock file is required in the
             root of your application, but none was found.
 
@@ -76,7 +76,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::InAppDirCacheError(error) => user::log_error(
             "Internal cache error",
-            format! {"
+            formatdoc! {"
             An internal error occured while caching files.
 
             Details:
@@ -86,7 +86,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::BundleInstallDigestError(error) => user::log_error(
             "Could not generate digest",
-            format! {"
+            formatdoc! {"
             To provide the fastest possible install experience the Ruby buildpack
             converts Gemfile and Gemfile.lock into a cryptographic digest to be
             used in cache invalidation.
@@ -99,7 +99,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::BundleInstallCommandError(error) => user::log_error(
             "Error installing bundler",
-            format! {"
+            formatdoc! {"
             Installation of bundler failed. Bundler is the package managment
             library for Ruby. Bundler is needed to install your application's dependencies
             listed in the Gemfile.
@@ -111,7 +111,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::RakeAssetsPrecompileFailed(error) => user::log_error(
             "Asset compilation failed",
-            format! {"
+            formatdoc! {"
             An error occured while compiling assets via rake command.
 
             Command failed:
@@ -121,7 +121,7 @@ fn log_our_error(error: RubyBuildpackError) {
         ),
         RubyBuildpackError::GemInstallBundlerCommandError(error) => user::log_error(
             "Installing gems failed",
-            format! {"
+            formatdoc! {"
             Could not install gems to the system via bundler. Gems are dependencies
             your application listed in the Gemfile and resolved in the Gemfile.lock.
 


### PR DESCRIPTION
- Use formatdoc! instead of format! in errors

We don't want to emit the extra whitespace here. Use `formatdoc!` macro instead of `format!` (by mistake).

This would be a hard one to catch. I wonder if there's a way to detect/warn on it somehow. Maybe with clippy and a custom rule?

- Add version to changelog and document. It's unintuitive why the first release was 2.0.0 so I added a note.