### PR TITLE
Exploded layer proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "fs_extra",
  "glob",
  "indoc",
+ "itertools 0.11.0",
  "lazy_static",
  "libcnb",
  "libcnb-test",
@@ -597,6 +598,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1364,7 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68ac9b870fb8707f12778b31fb122ec6cf1fc693af5be5fddaeb5341c0a7a4a"
 dependencies = [
  "is_executable",
- "itertools",
+ "itertools 0.10.5",
  "ordered-float",
  "rayon",
  "strsim",

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -29,6 +29,8 @@ walkdir = "2"
 which_problem = "0.1"
 ascii_table = { version = "4", features = ["color_codes"] }
 const_format = "0.2"
+toml = "0.8"
+itertools = "0.11.0"
 
 [dev-dependencies]
 indoc = "2"

--- a/commons/src/cache.rs
+++ b/commons/src/cache.rs
@@ -5,6 +5,7 @@ mod clean;
 mod config;
 mod error;
 mod in_app_dir_cache_layer;
+mod read_write_layer;
 
 pub use self::app_cache::{build, PathState};
 pub use self::app_cache::{AppCache, CacheState};
@@ -13,3 +14,6 @@ pub use self::clean::FilesWithSize;
 pub use self::config::CacheConfig;
 pub use self::config::{mib, KeepPath};
 pub use self::error::CacheError;
+pub use self::read_write_layer::{
+    metadata_diff, toml_delta, CachedLayer, CachedLayerData, MetadataDiff,
+};

--- a/commons/src/cache/read_write_layer.rs
+++ b/commons/src/cache/read_write_layer.rs
@@ -1,0 +1,195 @@
+use itertools::Itertools;
+use libcnb::build::BuildContext;
+use libcnb::data::layer::LayerName;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::layer::LayerData;
+use libcnb::layer::LayerResult;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::marker::PhantomData;
+use std::path::PathBuf;
+
+use crate::layer::{GetLayerData, SetLayerData};
+
+#[derive(Debug, Clone)]
+pub enum MetadataDiff<M> {
+    Same(M),
+    Different {
+        old: M,
+        now: M,
+    },
+    CannotDeserialize {
+        old: Option<toml::value::Table>,
+        now: M,
+    },
+    NoCache(M),
+}
+
+#[derive(Debug, Clone)]
+pub struct TomlDelta {
+    pub key: String,
+    pub old: Option<toml::Value>,
+    pub now: Option<toml::Value>,
+}
+
+/// Returns the delta between the two objects
+pub fn toml_delta<M: Serialize>(old: &M, now: &M) -> Vec<TomlDelta> {
+    let old = toml::to_string(&old)
+        .ok()
+        .and_then(|string| string.parse::<toml::Table>().ok())
+        .unwrap_or_default();
+
+    let now = toml::to_string(&now)
+        .ok()
+        .and_then(|string| string.parse::<toml::Table>().ok())
+        .unwrap_or_default();
+
+    let mut diff = Vec::new();
+    for key in old.keys().chain(now.keys()).unique() {
+        match (old.get(key).cloned(), now.get(key).cloned()) {
+            (old_value, now_value) if old_value != now_value => diff.push(TomlDelta {
+                key: key.clone(),
+                old: old_value.clone(),
+                now: now_value.clone(),
+            }),
+            _ => {}
+        }
+    }
+
+    diff
+}
+
+pub fn metadata_diff<M>(raw_metadata: &Option<toml::Table>, metadata: M) -> MetadataDiff<M>
+where
+    M: Serialize + DeserializeOwned + Eq + PartialEq + Clone,
+{
+    let cache_data = raw_metadata.clone();
+    if let Some(cache) = cache_data.clone() {
+        let old: Result<M, toml::de::Error> = cache.try_into();
+        match &old {
+            Ok(old) => {
+                if old == &metadata {
+                    MetadataDiff::Same(metadata)
+                } else {
+                    MetadataDiff::Different {
+                        old: old.clone(),
+                        now: metadata.clone(),
+                    }
+                }
+            }
+            Err(_) => MetadataDiff::CannotDeserialize {
+                old: cache_data,
+                now: metadata,
+            },
+        }
+    } else {
+        MetadataDiff::NoCache(metadata)
+    }
+}
+
+pub struct CachedLayer<M> {
+    pub name: LayerName,
+    pub build: bool,
+    pub launch: bool,
+    pub metadata: M,
+}
+
+impl<M> CachedLayer<M>
+where
+    M: Serialize + DeserializeOwned + Eq + PartialEq + Clone,
+{
+    /// # Errors
+    ///
+    /// TODO
+    pub fn read<B: libcnb::Buildpack>(
+        &self,
+        context: &BuildContext<B>,
+    ) -> Result<CachedLayerData<B, M>, libcnb::Error<B::Error>> {
+        let (read_name, write_name) = (clone_name(&self.name), clone_name(&self.name));
+
+        let data = context //
+            .handle_layer(
+                read_name,
+                GetLayerData::new(LayerTypes {
+                    cache: true,
+                    launch: self.launch,
+                    build: self.build,
+                }),
+            )?;
+
+        let name = write_name;
+        let path = data.path.clone();
+        let metadata_diff = metadata_diff(&data.content_metadata.metadata, self.metadata.clone());
+        let buildpack = PhantomData::<B>;
+        let layer_types = LayerTypes {
+            cache: true,
+            build: self.build,
+            launch: self.launch,
+        };
+
+        Ok(CachedLayerData {
+            name,
+            path,
+            layer_types,
+            metadata_diff,
+            buildpack,
+        })
+    }
+}
+
+fn clone_name(name: &LayerName) -> LayerName {
+    name.as_str()
+        .parse::<LayerName>()
+        .expect("Parsing a layer name from a layer name should be infailable")
+}
+
+pub struct CachedLayerData<B, M> {
+    pub name: LayerName,
+    pub path: PathBuf,
+    pub layer_types: LayerTypes,
+    pub metadata_diff: MetadataDiff<M>,
+
+    buildpack: PhantomData<B>,
+}
+
+impl<B, M> CachedLayerData<B, M> {
+    /// # Errors
+    ///
+    /// TODO
+    pub fn clear_path_contents(&self) -> Result<(), std::io::Error> {
+        // Ideally would return licnb::Error::HandleLayerError but the internal type not exposed
+        fs_err::remove_dir_all(&self.path)?;
+        fs_err::create_dir_all(&self.path)
+    }
+}
+
+impl<B, M> CachedLayerData<B, M>
+where
+    M: Serialize + DeserializeOwned + Eq + PartialEq + Clone,
+    B: libcnb::Buildpack,
+{
+    /// # Errors
+    ///
+    /// TODO
+    pub fn write(
+        &self,
+        context: &BuildContext<B>,
+        layer_result: LayerResult<M>,
+    ) -> Result<LayerData<M>, libcnb::Error<B::Error>> {
+        context.handle_layer(
+            clone_name(&self.name),
+            SetLayerData::new(
+                LayerTypes {
+                    cache: self.layer_types.cache,
+                    build: self.layer_types.build,
+                    launch: self.layer_types.launch,
+                },
+                layer_result,
+            ),
+        )
+    }
+
+    pub fn diff(&self) -> MetadataDiff<M> {
+        self.metadata_diff.clone()
+    }
+}

--- a/commons/src/layer.rs
+++ b/commons/src/layer.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::module_name_repetitions)]
 mod configure_env_layer;
 mod default_env_layer;
+mod get_layer_data;
+mod set_layer_data;
 
 pub use self::configure_env_layer::ConfigureEnvLayer;
 pub use self::default_env_layer::DefaultEnvLayer;
+pub use self::get_layer_data::GetLayerData;
+pub use self::set_layer_data::SetLayerData;

--- a/commons/src/layer/get_layer_data.rs
+++ b/commons/src/layer/get_layer_data.rs
@@ -1,0 +1,72 @@
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::layer_env::LayerEnv;
+use std::marker::PhantomData;
+use std::path::Path;
+
+/// A struct with one purpose: Retrieve prior `LayerData` from the last build (if there is any)
+#[derive(Debug)]
+pub struct GetLayerData<B> {
+    buildpack: PhantomData<B>,
+    layer_types: LayerTypes,
+}
+
+impl<B> GetLayerData<B> {
+    #[must_use]
+    pub fn new(layer_types: LayerTypes) -> Self {
+        Self {
+            buildpack: PhantomData,
+            layer_types,
+        }
+    }
+}
+
+impl<B> Layer for GetLayerData<B>
+where
+    B: libcnb::Buildpack,
+{
+    type Buildpack = B;
+    type Metadata = GenericMetadata;
+
+    /// An unfortunate byproduct of this interface is that we have to write layer types when we read
+    /// cached layer data.
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            launch: self.layer_types.launch,
+            build: self.layer_types.build,
+            cache: self.layer_types.cache,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as libcnb::Buildpack>::Error> {
+        LayerResultBuilder::new(GenericMetadata::default())
+            .env(LayerEnv::new())
+            .build()
+    }
+
+    fn existing_layer_strategy(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_data: &LayerData<Self::Metadata>,
+    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as libcnb::Buildpack>::Error> {
+        Ok(ExistingLayerStrategy::Keep)
+    }
+
+    fn migrate_incompatible_metadata(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _metadata: &libcnb::generic::GenericMetadata,
+    ) -> Result<
+        libcnb::layer::MetadataMigration<Self::Metadata>,
+        <Self::Buildpack as libcnb::Buildpack>::Error,
+    > {
+        eprint!("Warning: Clearing cache (Could not seriailize metadata from cache)");
+        Ok(libcnb::layer::MetadataMigration::RecreateLayer)
+    }
+}

--- a/commons/src/layer/set_layer_data.rs
+++ b/commons/src/layer/set_layer_data.rs
@@ -1,0 +1,99 @@
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult};
+use libcnb::Buildpack;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::path::Path;
+
+// Does everything but modifies the disk
+pub struct SetLayerData<B, M> {
+    buildpack: std::marker::PhantomData<B>,
+    layer_types: LayerTypes,
+    layer_result: LayerResult<M>,
+}
+
+impl<B, M> SetLayerData<B, M> {
+    pub fn new(layer_types: LayerTypes, layer_result: LayerResult<M>) -> Self {
+        Self {
+            buildpack: std::marker::PhantomData,
+            layer_types,
+            layer_result,
+        }
+    }
+}
+
+impl<B, M> Layer for SetLayerData<B, M>
+where
+    B: Buildpack,
+    M: Serialize + DeserializeOwned + Clone,
+{
+    type Buildpack = B;
+    type Metadata = M;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            launch: self.layer_types.launch,
+            build: self.layer_types.build,
+            cache: self.layer_types.cache,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+        let metadata = self.layer_result.metadata.clone();
+        let env = self.layer_result.env.clone();
+        let exec_d_programs = self.layer_result.exec_d_programs.clone();
+        let sboms = self.layer_result.sboms.clone();
+
+        Ok(LayerResult {
+            metadata,
+            env,
+            exec_d_programs,
+            sboms,
+        })
+    }
+
+    fn update(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_data: &LayerData<Self::Metadata>,
+    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+        let metadata = self.layer_result.metadata.clone();
+        let env = self.layer_result.env.clone();
+        let exec_d_programs = self.layer_result.exec_d_programs.clone();
+        let sboms = self.layer_result.sboms.clone();
+
+        Ok(LayerResult {
+            metadata,
+            env,
+            exec_d_programs,
+            sboms,
+        })
+    }
+
+    fn migrate_incompatible_metadata(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _metadata: &GenericMetadata,
+    ) -> Result<
+        libcnb::layer::MetadataMigration<Self::Metadata>,
+        <Self::Buildpack as Buildpack>::Error,
+    > {
+        Ok(libcnb::layer::MetadataMigration::ReplaceMetadata(
+            self.layer_result.metadata.clone(),
+        ))
+    }
+
+    fn existing_layer_strategy(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_data: &LayerData<Self::Metadata>,
+    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
+        Ok(ExistingLayerStrategy::Keep)
+    }
+}


### PR DESCRIPTION
The current design of the Layer trait encourages developers to put lots of logic into their layer. One impact of this, is it forces stateful logging to jump through hoops that I would call less ergonomic https://github.com/heroku/libcnb.rs/pull/669.

This proof of concept is a re-imagining of how we might want to interact with a layer using only the existing layer primitives from libcnb. It encourages operations to be performed outside of a layer because it does not require the developer to implement `Layer` on their own structs. Instead, it treats metadata as a primitive and makes "read" and "write" layer information their own discrete actions.

At a high level the flow of interacting with a layer now becomes:

- Read cached data (get LayerData)
- Do stuff (modify path, log, etc.)
- Write new data (write LayerResult)

In this process, I reimagined the flow for cache invalidation to fit within a `MetadataDiff` enum. This essentially encourages a set of "reasonable defaults" for equality-based metadata, but does not restrict to a specific use cases.

Worth noting that I've got an idea of a way to better handle metadata that cannot be deserialized, but it would be distracting from the primary purpose of this PoC.

## Known

The code in `main.rs` is quite long and would likely be moved to its own function if we continued down this path.

## Discussion/Feedback

The purpose of this PR is to get feedback on this approach, both high level (concept) and low level (implementation).