### PR TITLE
Group minor/patch version Rust Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "dependencies"
+      - "rust"
+      - "skip changelog"
     groups:
+      # Note: The group order matters, since updates are assigned to the first matching group.
       libcnb:
         patterns:
           - "libcnb*"
           - "libherokubuildpack"
+      rust-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github actions"
+      - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,10 +9,8 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-22.04
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Previously only libcnb related dependency updates were grouped into one Dependabot PR.

Now there is a second group, that takes advantage of Dependabot's new semver version level grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

In addition, the check changelog skipping strategy has been updated to use the explicit `skip changelog` label for (a) explicitness, (b) to allow removing the label in situations where we realise a changelog entry is required (eg libcnb buildpack API version bumps), (c) for consistency with other repos.

GUS-W-14258249.