### PR TITLE
Fix lint errors with Rust 1.73 and 1.74

### DIFF
--- a/buildpacks/ruby/src/gem_list.rs
+++ b/buildpacks/ruby/src/gem_list.rs
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn test_parsing_gem_list() {
         let gem_list = GemList::from_str(
-            r#"
+            r"
 Gems included by the bundle:
   * actioncable (6.1.4.1)
   * actionmailbox (6.1.4.1)
@@ -140,7 +140,7 @@ Gems included by the bundle:
   * ast (2.4.2)
   * railties (6.1.4.1)
 Use `bundle info` to print more detailed information about a gem
-            "#,
+            ",
         )
         .unwrap();
 

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -412,7 +412,7 @@ mod test {
         let env = layer_env.apply(Scope::All, &Env::new());
 
         let actual = commons::display::env_to_sorted_string(&env);
-        let expected = r#"
+        let expected = r"
 BUNDLE_BIN=layer_path/bin
 BUNDLE_CLEAN=1
 BUNDLE_DEPLOYMENT=1
@@ -420,7 +420,7 @@ BUNDLE_GEMFILE=app_path/Gemfile
 BUNDLE_PATH=layer_path
 BUNDLE_WITHOUT=development:test
 GEM_PATH=layer_path
-        "#;
+        ";
         assert_eq!(expected.trim(), actual.trim());
     }
 

--- a/buildpacks/ruby/src/layers/metrics_agent_install.rs
+++ b/buildpacks/ruby/src/layers/metrics_agent_install.rs
@@ -202,7 +202,7 @@ fn write_execd_script(
 }
 
 fn install_agentmon(dir: &Path) -> Result<PathBuf, MetricsAgentInstallError> {
-    let agentmon = download_untar(DOWNLOAD_URL, dir).map(|_| dir.join("agentmon"))?;
+    let agentmon = download_untar(DOWNLOAD_URL, dir).map(|()| dir.join("agentmon"))?;
 
     chmod_plus_x(&agentmon).map_err(MetricsAgentInstallError::PermissionError)?;
     Ok(agentmon)

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -135,7 +135,7 @@ fn download_url(stack: &StackId, version: impl std::fmt::Display) -> Result<Url,
     let mut url = Url::parse(base).map_err(RubyInstallError::UrlParseError)?;
 
     url.path_segments_mut()
-        .map_err(|_| RubyInstallError::InvalidBaseUrl(String::from(base)))?
+        .map_err(|()| RubyInstallError::InvalidBaseUrl(String::from(base)))?
         .push(stack)
         .push(&filename);
     Ok(url)

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -231,13 +231,13 @@ mod test {
 
     #[test]
     fn test_needs_java() {
-        let gemfile_lock = r#""#;
+        let gemfile_lock = r"";
         assert!(!needs_java(gemfile_lock));
 
-        let gemfile_lock = r#"
+        let gemfile_lock = r"
 RUBY VERSION
    ruby 2.5.7p001 (jruby 9.2.13.0)
-"#;
+";
         assert!(needs_java(gemfile_lock));
     }
 }

--- a/buildpacks/ruby/src/rake_task_detect.rs
+++ b/buildpacks/ruby/src/rake_task_detect.rs
@@ -82,7 +82,7 @@ mod tests {
     #[test]
     fn test_parsing_rake_dash_p() {
         let rake_detect = RakeDetect::from_str(
-            r#"
+            r"
 rake about
     environment
 rake action_mailbox:ingress:environment
@@ -123,7 +123,7 @@ rake assets:environment
 rake assets:precompile
     environment
     yarn:install
-        "#,
+        ",
         )
         .unwrap();
 

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -63,7 +63,7 @@ fn test_jruby_app() {
 
     fs_err::write(
         app_dir.path().join("Gemfile.lock"),
-        r#"
+        r"
 GEM
   remote: https://rubygems.org/
   specs:
@@ -72,7 +72,7 @@ PLATFORMS
 RUBY VERSION
    ruby 2.6.8p001 (jruby 9.3.6.0)
 DEPENDENCIES
-"#,
+",
     )
     .unwrap();
 

--- a/commons/src/gemfile_lock.rs
+++ b/commons/src/gemfile_lock.rs
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn test_parse_gemfile_lock() {
         let info = GemfileLock::from_str(
-            r#"
+            r"
 GEM
   remote: https://rubygems.org/
   specs:
@@ -172,7 +172,7 @@ RUBY VERSION
 
 BUNDLED WITH
    2.3.4
-"#,
+",
         )
         .unwrap();
 
@@ -196,7 +196,7 @@ BUNDLED WITH
     #[test]
     fn test_jruby() {
         let info = GemfileLock::from_str(
-            r#"
+            r"
 GEM
   remote: https://rubygems.org/
   specs:
@@ -205,7 +205,7 @@ PLATFORMS
 RUBY VERSION
    ruby 2.5.7p001 (jruby 9.2.13.0)
 DEPENDENCIES
-"#,
+",
         )
         .unwrap();
 


### PR DESCRIPTION
To unblock #217.

Fixed using `cargo clippy --all-targets --fix`.

`warning: matching over () is more explicit`
https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns

`warning: unnecessary hashes around raw string literal` https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes

As seen in:
https://github.com/heroku/buildpacks-ruby/actions/runs/6456039106/job/17524710712?pr=217

GUS-W-14258338.