### PR TITLE
Update buildpack metadata in buildpack.toml

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#223](https://github.com/heroku/buildpack-ruby/pull/223))
+
 ## [2.1.0] - 2023-09-26
 
 ### Added

--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Updated buildpack display name, description and keywords. ([#223](https://github.com/heroku/buildpack-ruby/pull/223))
 

--- a/buildpacks/ruby/buildpack.toml
+++ b/buildpacks/ruby/buildpack.toml
@@ -3,10 +3,13 @@ api = "0.9"
 [buildpack]
 id = "heroku/ruby"
 version = "2.1.0"
-name = "Ruby"
+name = "Heroku Ruby"
 homepage = "https://github.com/heroku/buildpacks-ruby"
-description = "Official Heroku buildpack for using Ruby to target Cloud Native Buildpack (CNB) builds."
-keywords = ["ruby", "rails"]
+description = "Heroku's buildpack for Ruby applications."
+keywords = ["ruby", "rails", "heroku"]
+
+[[buildpack.licenses]]
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-20"
@@ -14,10 +17,5 @@ id = "heroku-20"
 [[stacks]]
 id = "heroku-22"
 
-[[buildpack.licenses]]
-type = "BSD-3-Clause"
-
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-ruby"
+image = { repository = "docker.io/heroku/buildpack-ruby" }


### PR DESCRIPTION
Adjusts the buildpack `name`, `description` and `keywords` in `buildpack.toml` to match the style discussed in:
https://github.com/heroku/cnb-builder-images/issues/408

These fields are used by the CNB registry and can also be seen in the output of `pack builder inspect`. They are not used by `pack build` or Kodon.

In addition, I've cleaned up the `[metadata]` table/subtables to match the more concise style used by the Procfile and Python CNBs.

GUS-W-14121598.