### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,14 @@
 [workspace]
 resolver = "2"
 members = ["buildpacks/ruby", "commons"]
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.74"
+
+[workspace.lints.rust]
+unused_crate_dependencies = "warn"
+
+[workspace.lints.clippy]
+pedantic = "warn"
+module_name_repetitions = "allow"

--- a/buildpacks/ruby/Cargo.toml
+++ b/buildpacks/ruby/Cargo.toml
@@ -3,8 +3,11 @@ name = "heroku-ruby-buildpack"
 # This crate is not published, so the only version that is used is the one in buildpack.toml.
 version = "0.0.0"
 publish = false
-edition = "2021"
-rust-version = "1.66"
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 commons = { path = "../../commons" }

--- a/buildpacks/ruby/src/bin/agentmon_loop.rs
+++ b/buildpacks/ruby/src/bin/agentmon_loop.rs
@@ -1,6 +1,5 @@
-// Enable Clippy lints that are disabled by default.
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use clap::Parser;
 use std::ffi::OsStr;

--- a/buildpacks/ruby/src/bin/launch_daemon.rs
+++ b/buildpacks/ruby/src/bin/launch_daemon.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use clap::Parser;
 use std::path::PathBuf;
 use std::process::exit;
@@ -75,7 +78,7 @@ fn main() {
             eprintln!(
                 "Could not write to log file {}. Reason: {error}",
                 log.display()
-            )
+            );
         });
 
         command.args(["--output", &log.to_string_lossy()]);
@@ -88,7 +91,7 @@ fn main() {
             eprintln!(
                 "Could not write to log file {}. Reason: {error}",
                 log.display()
-            )
+            );
         });
     }
 

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
 use commons::cache::CacheError;
 use commons::gemfile_lock::GemfileLock;
 use commons::metadata_digest::MetadataDigest;

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -1,4 +1,5 @@
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb_test::{
     assert_contains, assert_empty, BuildConfig, BuildpackReference, ContainerConfig,

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "commons"
 version = "1.0.0"
-edition = "2021"
 publish = false
+edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "print_style_guide"
 path = "bin/print_style_guide.rs"
+
+[lints]
+workspace = true
 
 [dependencies]
 byte-unit = "4"

--- a/commons/bin/print_style_guide.rs
+++ b/commons/bin/print_style_guide.rs
@@ -1,5 +1,9 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use ascii_table::AsciiTable;
 use commons::output::fmt::{self, DEBUG_INFO, HELP};
+#[allow(clippy::wildcard_imports)]
 use commons::output::{
     build_log::*,
     section_log::{log_step, log_step_stream, log_step_timed},
@@ -9,6 +13,7 @@ use indoc::formatdoc;
 use std::io::stdout;
 use std::process::Command;
 
+#[allow(clippy::too_many_lines)]
 fn main() {
     println!(
         "{}",

--- a/commons/src/cache.rs
+++ b/commons/src/cache.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::module_name_repetitions)]
 mod app_cache;
 mod app_cache_collection;
 mod clean;

--- a/commons/src/cache/config.rs
+++ b/commons/src/cache/config.rs
@@ -2,7 +2,6 @@ use byte_unit::{n_mib_bytes, Byte};
 use std::path::PathBuf;
 
 /// Configure behavior of a cached path
-#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheConfig {
     /// Path to the directory you want to cache

--- a/commons/src/cache/error.rs
+++ b/commons/src/cache/error.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(thiserror::Error, Debug)]
 pub enum CacheError {
     #[error("Cached path not in application directory: {0}")]

--- a/commons/src/layer.rs
+++ b/commons/src/layer.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::module_name_repetitions)]
 mod configure_env_layer;
 mod default_env_layer;
 

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -1,6 +1,3 @@
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-
 // Used in both testing and printing the style guide
 use indoc as _;
 

--- a/commons/src/output/build_log.rs
+++ b/commons/src/output/build_log.rs
@@ -31,7 +31,6 @@ use std::time::{Duration, Instant};
 ///
 /// For usage details run `cargo run --bin print_style_guide`
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub struct BuildLog<T, W: Debug> {
     pub(crate) io: W,

--- a/commons/src/output/warn_later.rs
+++ b/commons/src/output/warn_later.rs
@@ -123,7 +123,6 @@ fn take() -> Option<Vec<String>> {
     WARN_LATER.with(|cell| cell.replace(None))
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub enum WarnLaterError {
     MissingGuardForThread(ThreadId),


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table

This reduces the boilerplate, and the chance that we forget to enable lints in some targets. The only thing we need to remember is to add the `[lints] workspace = true` to any new crates in the future.

Making this switch exposed a few places where lints weren't enabled and issues had been missed, which have been fixed now.

Since this feature requires Rust 1.74, the MSRV has also been bumped (however, libcnb 0.16.0 already requires Rust 1.74, so in practice this is a no-op).

GUS-W-14523799.