### PR TITLE
Report io error when detect cannot read a file.

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `fun_run` commons library was moved to it's own crate ([#232](https://github.com/heroku/buildpacks-ruby/pull/232))
 
+### Added
+
+- Raise a helpful error when a file cannot be accessed at the time of buildpack detection ([#243](https://github.com/heroku/buildpacks-ruby/pull/243))
+
+
 ## [2.1.2] - 2023-10-31
 
 ### Fixed

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -6,7 +6,7 @@ use commons::output::{
     fmt::{self, DEBUG_INFO},
 };
 
-use crate::RubyBuildpackError;
+use crate::{DetectError, RubyBuildpackError};
 use fun_run::{CmdError, CommandWithName};
 use indoc::formatdoc;
 
@@ -45,6 +45,62 @@ fn log_our_error(mut log: Box<dyn StartedLogger>, error: RubyBuildpackError) {
     let rubygems_status_url = fmt::url("https://status.rubygems.org/");
 
     match error {
+        RubyBuildpackError::BuildpackDetectionError(DetectError::Gemfile(error)) => {
+            log.announce().error(&formatdoc! {"
+                Error: `Gemfile` found with error
+
+                There was an error trying to read the contents of the application's Gemfile.
+                The buildpack cannot continue if the Gemfile is unreadable.
+
+                {error}
+
+                Debug using the above information and try again.
+            "});
+        }
+        RubyBuildpackError::BuildpackDetectionError(DetectError::PackageJson(error)) => {
+            log.announce().error(&formatdoc! {"
+                Error: `package.json` found with error
+
+                The Ruby buildpack detected a package.json file but it is not readable
+                due to the following errors:
+
+                {error}
+
+                If your application does not need any node dependencies installed,
+                you may delete this file and try again.
+
+                If you are expecting node dependencies to be installed, please
+                debug using the above information and try again.
+            "});
+        }
+        RubyBuildpackError::BuildpackDetectionError(DetectError::GemfileLock(error)) => {
+            log.announce().error(&formatdoc! {"
+                Error: `Gemfile.lock` found with error
+
+                There was an error trying to read the contents of the application's Gemfile.lock.
+                The buildpack cannot continue if the Gemfile is unreadable.
+
+                {error}
+
+                Debug using the above information and try again.
+            "});
+        }
+        RubyBuildpackError::BuildpackDetectionError(DetectError::YarnLock(error)) => {
+            log.announce().error(&formatdoc! {"
+                Error: `yarn.lock` found with error
+
+                The Ruby buildpack detected a yarn.lock file but it is not readable
+                due to the following errors:
+
+                {error}
+
+                If your application does not need yarn installed, you
+                may delete this file and try again.
+
+                If you are expecting yarn to be installed, please
+                debug using the above information and try again.
+            "});
+        }
         RubyBuildpackError::MissingGemfileLock(path, error) => {
             log = log
                 .section(&format!(

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -49,8 +49,8 @@ fn log_our_error(mut log: Box<dyn StartedLogger>, error: RubyBuildpackError) {
             log.announce().error(&formatdoc! {"
                 Error: `Gemfile` found with error
 
-                There was an error trying to read the contents of the application's Gemfile.
-                The buildpack cannot continue if the Gemfile is unreadable.
+              There was an error trying to read the contents of the application's Gemfile. \
+              The buildpack cannot continue if the Gemfile is unreadable.
 
                 {error}
 
@@ -61,15 +61,15 @@ fn log_our_error(mut log: Box<dyn StartedLogger>, error: RubyBuildpackError) {
             log.announce().error(&formatdoc! {"
                 Error: `package.json` found with error
 
-                The Ruby buildpack detected a package.json file but it is not readable
+                The Ruby buildpack detected a package.json file but it is not readable \
                 due to the following errors:
 
                 {error}
 
-                If your application does not need any node dependencies installed,
+                If your application does not need any node dependencies installed, \
                 you may delete this file and try again.
 
-                If you are expecting node dependencies to be installed, please
+                If you are expecting node dependencies to be installed, please \
                 debug using the above information and try again.
             "});
         }
@@ -77,7 +77,7 @@ fn log_our_error(mut log: Box<dyn StartedLogger>, error: RubyBuildpackError) {
             log.announce().error(&formatdoc! {"
                 Error: `Gemfile.lock` found with error
 
-                There was an error trying to read the contents of the application's Gemfile.lock.
+                There was an error trying to read the contents of the application's Gemfile.lock. \
                 The buildpack cannot continue if the Gemfile is unreadable.
 
                 {error}
@@ -89,15 +89,15 @@ fn log_our_error(mut log: Box<dyn StartedLogger>, error: RubyBuildpackError) {
             log.announce().error(&formatdoc! {"
                 Error: `yarn.lock` found with error
 
-                The Ruby buildpack detected a yarn.lock file but it is not readable
+                The Ruby buildpack detected a yarn.lock file but it is not readable \
                 due to the following errors:
 
                 {error}
 
-                If your application does not need yarn installed, you
+                If your application does not need yarn installed, you \
                 may delete this file and try again.
 
-                If you are expecting yarn to be installed, please
+                If you are expecting yarn to be installed, please \
                 debug using the above information and try again.
             "});
         }


### PR DESCRIPTION
It's best practice to use `try_exists()` instead of `exists()` when checking if a file exists or not because if there's a problem with the file (such as a permissions issue) then the check might fail even though the file is on disk. This seems like not a big deal, but can be very confusing when telling users "we didn't do X because you are missing file Y" but when they debug they see file Y and don't realize that the real problem isn't "missing file" but it's the hidden error preventing `exists()` from returning a true.


This commit uses fs_err_try_exists() from fs-err library that was introduced in: https://github.com/andrewhickman/fs-err/pull/48.

There are a few other places where `exists` is still called, those are nested in areas that don't already return a Result so they're harder to swap.