### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "commons"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "ascii_table",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["buildpacks/ruby", "commons"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.75"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/ruby/Cargo.toml
+++ b/buildpacks/ruby/Cargo.toml
@@ -1,8 +1,5 @@
 [package]
 name = "heroku-ruby-buildpack"
-# This crate is not published, so the only version that is used is the one in buildpack.toml.
-version = "0.0.0"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
 name = "commons"
-version = "1.0.0"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.