### PR TITLE
Use `pack build --force-color` in CI instead of `script` TTY workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,22 +74,23 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.5.2
-      - name: Pull builder image
+      - name: Pull builder and run images
         run: |
           docker pull "heroku/builder:22"
           docker pull "heroku/heroku:22-cnb"
       - name: Clone ruby getting started guide
-        run: mkdir tmp; git clone https://github.com/heroku/ruby-getting-started tmp/ruby-getting-started
+        uses: actions/checkout@v4
+        with:
+          repository: heroku/ruby-getting-started
+          path: tmp/ruby-getting-started
       - name: Install libcnb-cargo for `cargo libcnb package` command
         run: cargo install libcnb-cargo
       - name: Compile ruby buildpack
         run: cargo libcnb package
       - name: "PRINT: Getting started guide output"
-        run: | # Use `script -e -c` to pretend to be a TTY for pack terminal color support
-          script -e -c "pack build my-image --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never"
+        run: pack build my-image --force-color --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
       - name: "PRINT: Cached getting started guide output"
-        run: | # Use `script -e -c` to pretend to be a TTY for pack terminal color support
-          script -e -c "pack build my-image --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never"
+        run: pack build my-image --force-color --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
 
   print-style-guide:
     runs-on: ubuntu-22.04
@@ -104,8 +105,5 @@ jobs:
         run: rustup target add x86_64-unknown-linux-musl
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
-      - name: Build binary
-        run: cargo build --bin print_style_guide
       - name: "PRINT: Style guide"
-        run: | # Use `script -e -c` to pretend to be a TTY for pack terminal color support
-          script -e -c "cargo run --bin print_style_guide"
+        run: cargo run --quiet --bin print_style_guide


### PR DESCRIPTION
As of Pack 0.33.0 (which this repo is using thanks to #462), there is a new `--force-color` argument that makes `pack build` output logs in colour even if a TTY wasn't detected (as is the case on GHA):
https://github.com/buildpacks/pack/releases/tag/v0.33.0

This makes the `script -e -c` TTY workaround unnecessary. (It's also not needed for any direct Cargo usages, since they are covered by the existing `CARGO_TERM_COLOR: always`.)

I've also:
 - removed a redundant `cargo build` step (run does a build, and the Cargo compilation output can be suppressed using `--quiet`)
- replaced a manual git clone with `actions/checkout`, since it handles things like retries, faster shallow clones etc.

GUS-W-14968745.