### PR TITLE
Apply clippy suggestion

### DIFF
--- a/commons/src/output/warn_later.rs
+++ b/commons/src/output/warn_later.rs
@@ -8,7 +8,7 @@ use std::thread::ThreadId;
 
 pub type PhantomUnsync = PhantomData<Rc<()>>;
 
-thread_local!(static WARN_LATER: RefCell<Option<Vec<String>>> = RefCell::new(None));
+thread_local!(static WARN_LATER: RefCell<Option<Vec<String>>> = const { RefCell::new(None) });
 
 /// Queue a warning for later
 ///


### PR DESCRIPTION
CI started failing when a new rust was released with new clippy suggestions. This is failing on main:

```
error: initializer for `thread_local` value can be made `const`
  --> commons/src/output/warn_later.rs:11:65
   |
11 | thread_local!(static WARN_LATER: RefCell<Option<Vec<String>>> = RefCell::new(None));
   |                                                                 ^^^^^^^^^^^^^^^^^^ help: replace with: `const { RefCell::new(None) }`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#thread_local_initializer_can_be_made_const
   = note: `-D clippy::thread-local-initializer-can-be-made-const` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::thread_local_initializer_can_be_made_const)]`

error: could not compile `commons` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `commons` (lib test) due to 1 previous error
```