### PR TITLE
Support heroku-24

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `heroku-24` / `heroku/builder:24`. ([#280](https://github.com/heroku/buildpacks-ruby/pull/280))
+
 ## [2.1.3] - 2024-03-18
 
 ### Changed

--- a/buildpacks/ruby/buildpack.toml
+++ b/buildpacks/ruby/buildpack.toml
@@ -17,5 +17,8 @@ id = "heroku-20"
 [[stacks]]
 id = "heroku-22"
 
+[[stacks]]
+id = "heroku-24"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-ruby" }

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -254,4 +254,12 @@ version = "3.1.3"
             format!("https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-24/{}/ruby-3.1.4.tgz", ruby_arch().unwrap()),
         );
     }
+
+    #[test]
+    fn test_ruby_arch() {
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!("arm64", ruby_arch().unwrap());
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!("amd64", ruby_arch().unwrap());
+    }
 }

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -149,6 +149,7 @@ fn download_url(stack: &StackId, version: impl std::fmt::Display) -> Result<Url,
 
 fn ruby_arch() -> Result<String, RubyInstallError> {
     match consts::ARCH {
+        "aarch64" => Ok(String::from("arm64")),
         "x86_64" => Ok(String::from("amd64")),
         _ => Err(RubyInstallError::UnsupportedArchitecture(String::from(
             consts::ARCH,


### PR DESCRIPTION
This PR adds support for heroku-24 including downloading arch specific Ruby binaries depending on the current host architecture.

The cache isn't currently invalidated if the host architecture changes.