### PR TITLE
Support Heroku-24 and ARM architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,9 +1036,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- The buildpack now implements Buildpack API 0.10 instead of 0.9, and so requires `lifecycle` 0.17.x or newer. ([#283](https://github.com/heroku/buildpacks-ruby/pull/283/files#commit-suggestions))
+### Changed
+
+- The buildpack now implements Buildpack API 0.10 instead of 0.9, and so requires `lifecycle` 0.17.x or newer. ([#283](https://github.com/heroku/buildpacks-ruby/pull/283))
+
+### Added
+
+- Added support for Ubuntu 24.04 (and thus Heroku-24 / `heroku/builder:24`). ([#284](https://github.com/heroku/buildpacks-ruby/pull/284))
+
+### Fixed
 
 ## [2.1.3] - 2024-03-18
 

--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for Ubuntu 24.04 (and thus Heroku-24 / `heroku/builder:24`). ([#284](https://github.com/heroku/buildpacks-ruby/pull/284))
 
-### Fixed
-
 ## [2.1.3] - 2024-03-18
 
 ### Changed

--- a/buildpacks/ruby/buildpack.toml
+++ b/buildpacks/ruby/buildpack.toml
@@ -28,5 +28,17 @@ version = "20.04"
 name = "ubuntu"
 version = "22.04"
 
+[[targets.distros]]
+name = "ubuntu"
+version = "24.04"
+
+[[targets]]
+os = "linux"
+arch = "arm64"
+
+[[targets.distros]]
+name = "ubuntu"
+version = "24.04"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-ruby" }

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -236,11 +236,18 @@ fn download_url(
     let filename = format!("ruby-{version}.tgz");
     let base = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com";
     let mut url = Url::parse(base).map_err(RubyInstallError::UrlParseError)?;
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|()| RubyInstallError::InvalidBaseUrl(String::from(base)))?;
 
-    url.path_segments_mut()
-        .map_err(|()| RubyInstallError::InvalidBaseUrl(String::from(base)))?
-        .push(&target.stack_name().map_err(RubyInstallError::TargetError)?)
-        .push(&filename);
+        segments.push(&target.stack_name().map_err(RubyInstallError::TargetError)?);
+        if target.is_arch_aware() {
+            segments.push(&target.cpu_architecture);
+        }
+        segments.push(&filename);
+    }
+
     Ok(url)
 }
 

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -289,9 +289,9 @@ fn amd_arm_builder_config(builder_name: &str, app_dir: &str) -> BuildConfig {
 
     match builder_name {
         "heroku/builder:24" if cfg!(target_arch = "aarch64") => {
-            builder.target_triple("aarch64-unknown-linux-musl")
+            config.target_triple("aarch64-unknown-linux-musl")
         }
-        _ => builder.target_triple("x86_64-unknown-linux-musl"),
+        _ => config.target_triple("x86_64-unknown-linux-musl"),
     };
     config
 }

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -16,6 +16,11 @@ use ureq::Response;
 #[test]
 #[ignore = "integration test"]
 fn test_migrating_metadata() {
+    // This test is a placeholder for when a change modifies metadata structures.
+    // Remove the return and update the `buildpack-ruby` reference to the latest version.
+    #![allow(unreachable_code)]
+    return;
+
     let builder = "heroku/builder:22";
     let app_dir = "tests/fixtures/default_ruby";
 
@@ -57,9 +62,26 @@ fn test_default_app_ubuntu20() {
 
 #[test]
 #[ignore = "integration test"]
-fn test_default_app_latest_distro() {
+fn test_default_app_ubuntu22() {
     TestRunner::default().build(
         BuildConfig::new("heroku/builder:22", "tests/fixtures/default_ruby"),
+        |context| {
+            println!("{}", context.pack_stdout);
+            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            assert_contains!(
+                context.pack_stdout,
+                r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
+
+            assert_contains!(context.pack_stdout, "Installing webrick");
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_default_app_latest_distro() {
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:24", "tests/fixtures/default_ruby"),
         |context| {
             println!("{}", context.pack_stdout);
             assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -285,7 +285,7 @@ const TEST_PORT: u16 = 1234;
 // TODO: Once Pack build supports `--platform` and libcnb-test adjusted accordingly, change this
 // to allow configuring the target arch independently of the builder name (eg via env var).
 fn amd_arm_builder_config(builder_name: &str, app_dir: &str) -> BuildConfig {
-    let mut builder = BuildConfig::new(builder_name, app_dir);
+    let mut config = BuildConfig::new(builder_name, app_dir);
 
     match builder_name {
         "heroku/builder:24" if cfg!(target_arch = "aarch64") => {
@@ -293,5 +293,5 @@ fn amd_arm_builder_config(builder_name: &str, app_dir: &str) -> BuildConfig {
         }
         _ => builder.target_triple("x86_64-unknown-linux-musl"),
     };
-    builder
+    config
 }


### PR DESCRIPTION
Heroku 24 stack image supports both arm64 and amd64. The Ruby binaries are available on heroku-24 compiled to these two stacks https://github.com/heroku/docker-heroku-ruby-builder/pull/38. The buildpack adds support by:

- Updating the `buildpackl.toml` to include ARM architecture
- Using architecture information to build the URL for Ubuntu 24.04 (heroku-24)
- Integration testing on all supported Ubuntu versions