### PR TITLE
update builder to heroku-24 on print getting started guide github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Pull builder and run images
         run: |
           docker pull "heroku/builder:24"
-          docker pull "heroku/heroku:24-cnb"
+          docker pull "heroku/heroku:24"
       - name: Clone ruby getting started guide
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Compile ruby buildpack
         run: cargo libcnb package
       - name: "PRINT: Getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:24 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
       - name: "PRINT: Cached getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:24 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
 
   print-style-guide:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
         uses: buildpacks/github-actions/setup-pack@v5.7.1
       - name: Pull builder and run images
         run: |
-          docker pull "heroku/builder:22"
-          docker pull "heroku/heroku:22-cnb"
+          docker pull "heroku/builder:24"
+          docker pull "heroku/heroku:24-cnb"
       - name: Clone ruby getting started guide
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
-        uses: buildpacks/github-actions/setup-pack@v5.6.0
+        uses: buildpacks/github-actions/setup-pack@v5.7.1
       - name: Run integration tests
         # Runs only tests annotated with the `ignore` attribute (which in this repo, are the integration tests).
         run: cargo test --locked -- --ignored
@@ -73,7 +73,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
-        uses: buildpacks/github-actions/setup-pack@v5.6.0
+        uses: buildpacks/github-actions/setup-pack@v5.7.1
       - name: Pull builder and run images
         run: |
           docker pull "heroku/builder:22"


### PR DESCRIPTION
Heroku 24 is now a trusted and suggested builder in [pack](https://github.com/buildpacks/pack/pull/2178). However, now running pack build with heroku-22 now fails due to a bug that suggests the builder is not trusted even though it is configured to be. 
```
Run pack build my-image --force-color --builder heroku/builder:22 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never 
ERROR: failed to build: fetching lifecycle image: image buildpacksio/lifecycle:0.19.6 does not exist on the daemon: not found
``` 

We can update the version of the heroku builder that the github workflow for printing getting started is using in order for this action to pass. 