### PR TITLE
Test getting started guide with ARM && AMD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,20 @@ jobs:
         run: cargo test --locked -- --ignored
 
   print-pack-getting-started-output:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'pub-hk-ubuntu-22.04-arm-medium' || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        target: ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install musl-tools
-        run: sudo apt-get install musl-tools --no-install-recommends
+        run: sudo apt-get install -y --no-install-recommends musl-tools
       - name: Update Rust toolchain
         run: rustup update
       - name: Install Rust linux-musl target
-        run: rustup target add x86_64-unknown-linux-musl
+        run: rustup target add ${{ matrix.target }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
@@ -86,11 +90,11 @@ jobs:
       - name: Install libcnb-cargo for `cargo libcnb package` command
         run: cargo install libcnb-cargo
       - name: Compile ruby buildpack
-        run: cargo libcnb package
+        run: cargo libcnb package --target ${{ matrix.target }}
       - name: "PRINT: Getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:24 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:24 --buildpack heroku/nodejs-engine --buildpack packaged/${{ matrix.target }}/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
       - name: "PRINT: Cached getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:24 --buildpack heroku/nodejs-engine --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:24 --buildpack heroku/nodejs-engine --buildpack packaged/${{ matrix.target }}/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
 
   print-style-guide:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Previously, all Heroku runners used AMD (x86) CPU architecture. We added the ability to build and run on an ARM machine (aarch64, like an M3 Mac), but building binaries for ARM required a beta GitHub Action (GHA) runner. The GHA runner beta required extra invocations to setup tools on the machine (such as installing docker). 

The GHA ARM runners are now out of beta. This PR adds a test that exercises the ARM codepath on CI in addition to the existing AMD codepath.

GUS-W-15805220