### PR TITLE
Configure process to complain about unset variable

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The buildpack now warns the user when environmental variables used in running process is not defined. ([#307](https://github.com/heroku/buildpacks-ruby/pull/307))
+
 ## [3.0.0] - 2024-05-17
 
 ### Changed

--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- The buildpack now warns the user when environmental variables used in running process is not defined. ([#307](https://github.com/heroku/buildpacks-ruby/pull/307))
+- The buildpack now warns the user when environmental variables used in running the default process are not defined. ([#307](https://github.com/heroku/buildpacks-ruby/pull/307))
 
 ## [3.0.0] - 2024-05-17
 

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -76,7 +76,7 @@ fn default_rack() -> Process {
             "-c",
             &[
                 "bundle exec rackup",
-                "--port \"$PORT\"",
+                "--port \"${PORT:?Error: PORT env var is not set!}\"",
                 "--host \"0.0.0.0\"",
             ]
             .join(" "),
@@ -91,7 +91,7 @@ fn default_rails() -> Process {
             "-c",
             &[
                 "bin/rails server",
-                "--port \"$PORT\"",
+                "--port \"${PORT:?Error: PORT env var is not set!}\"",
                 "--environment \"$RAILS_ENV\"",
             ]
             .join(" "),


### PR DESCRIPTION
When using `docker run`, the default rails app configuration assumes the existence of a `$PORT` environmental variable but does not tell the user that it is required. By making the lack of a definition for the environmental variable, the user can understand how to run the application properly.

Resolves #306 