### PR TITLE
Migrate metrics agent layer to Struct API and bullet Stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bullet_stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec939946cfeb7d4ba709fb24f035a14b78b89641cd4a09434a6d317c0ae28a6"
+
+[[package]]
 name = "byte-unit"
 version = "4.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +468,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "heroku-ruby-buildpack"
 version = "0.0.0"
 dependencies = [
+ "bullet_stream",
  "clap",
  "commons",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,13 +573,13 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libcnb"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc89bfeaef5f43cdee664798e3c0aa36e052a412ab1391f0750aee4df1f407"
+checksum = "b4b3e7c4d57d10b3e2a76b15fb3ae98a56be73655325ae26723fcb6a4709fd64"
 dependencies = [
- "libcnb-common",
- "libcnb-data",
- "libcnb-proc-macros",
+ "libcnb-common 0.23.0",
+ "libcnb-data 0.23.0",
+ "libcnb-proc-macros 0.23.0",
  "serde",
  "thiserror",
  "toml",
@@ -597,13 +597,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcnb-common"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719c4b07c0d221587a49919308c88fa41e01256e533da643c6cde0a88840cccb"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "libcnb-data"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd102bfb1bf98ee4c18da0b29be6f23a19681937924bf758e9ea8499668b18"
 dependencies = [
  "fancy-regex",
- "libcnb-proc-macros",
+ "libcnb-proc-macros 0.21.0",
+ "serde",
+ "thiserror",
+ "toml",
+ "uriparse",
+]
+
+[[package]]
+name = "libcnb-data"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab235141d51d47ecffd1fc7a8efc2851063048ba9d4498963f1ad963c275eee"
+dependencies = [
+ "fancy-regex",
+ "libcnb-proc-macros 0.23.0",
  "serde",
  "thiserror",
  "toml",
@@ -619,8 +644,8 @@ dependencies = [
  "cargo_metadata",
  "ignore",
  "indoc",
- "libcnb-common",
- "libcnb-data",
+ "libcnb-common 0.21.0",
+ "libcnb-data 0.21.0",
  "petgraph",
  "thiserror",
  "uriparse",
@@ -640,6 +665,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcnb-proc-macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8d7feb9d84bdd3b9f6ff892508f78e1a75c39a6ab8f247f6106bd2d9bae489"
+dependencies = [
+ "cargo_metadata",
+ "fancy-regex",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "libcnb-test"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,8 +684,8 @@ checksum = "9471152703833b74d565c7f7c910b4d5e084f955c327eba2bdb6658e86bd6dd6"
 dependencies = [
  "fastrand",
  "fs_extra",
- "libcnb-common",
- "libcnb-data",
+ "libcnb-common 0.21.0",
+ "libcnb-data 0.21.0",
  "libcnb-package",
  "tempfile",
  "thiserror",
@@ -795,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]

--- a/buildpacks/ruby/Cargo.toml
+++ b/buildpacks/ruby/Cargo.toml
@@ -16,7 +16,7 @@ glob = "0.3"
 indoc = "2"
 # libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
 # so it's pinned to an exact version to isolate it from lockfile refreshes.
-libcnb = "=0.21.0"
+libcnb = "=0.23.0"
 libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["digest"] }
 rand = "0.8"
 # TODO: Consolidate on either the regex crate or the fancy-regex crate, since this repo currently uses both.

--- a/buildpacks/ruby/Cargo.toml
+++ b/buildpacks/ruby/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+bullet_stream = "0.2.0"
 clap = { version = "4", default-features = false, features = ["derive", "error-context", "help", "std", "usage"] }
 commons = { path = "../../commons" }
 flate2 = { version = "1", default-features = false, features = ["zlib"] }

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -8,6 +8,7 @@ use commons::output::{
 use fun_run::{self, CommandWithName};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Env;
@@ -32,6 +33,7 @@ pub(crate) struct BundleDownloadLayer<'a> {
     pub(crate) _section_logger: &'a dyn SectionLogger,
 }
 
+#[allow(deprecated)]
 impl<'a> Layer for BundleDownloadLayer<'a> {
     type Buildpack = RubyBuildpack;
     type Metadata = BundleDownloadLayerMetadata;

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -8,10 +8,11 @@ use commons::{
 };
 use fun_run::CommandWithName;
 use fun_run::{self, CmdError};
+#[allow(deprecated)]
+use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::{
     build::BuildContext,
     data::layer_content_metadata::LayerTypes,
-    layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder},
     layer_env::{LayerEnv, ModificationBehavior, Scope},
     Env,
 };
@@ -149,6 +150,7 @@ fn update_state(old: &BundleInstallLayerMetadata, now: &BundleInstallLayerMetada
     }
 }
 
+#[allow(deprecated)]
 impl Layer for BundleInstallLayer<'_> {
     type Buildpack = RubyBuildpack;
     type Metadata = BundleInstallLayerMetadata;

--- a/buildpacks/ruby/src/layers/metrics_agent_install.rs
+++ b/buildpacks/ruby/src/layers/metrics_agent_install.rs
@@ -97,23 +97,16 @@ pub(crate) fn handle_metrics_agent_layer(
                     log_step("Clearing cache (invalid metadata)");
                 }
                 EmptyLayerCause::RestoredLayerAction { cause: Some(url) } => {
-                    // This should probably be updated to "Updating cached metrics agent (from {url} to {DOWNLOAD_URL}"
-                    // or some other language that reflects the cache metrics agent is being updated. Alternatively,
-                    // this could simply state "Deleting cached metrics agent ({url}) if the "Downloading" log below
-                    // is updated to include the new download URL.
-                    // Including original language to show a 1:1 migration from Layer to Struct API, retaining full
-                    // functionality/behavior without refactoring.
-                    log_step(format!(
-                        "Using cached metrics agent ({url} to {DOWNLOAD_URL}"
-                    ));
+                    log_step(format!("Deleting cached metrics agent ({url})"));
                 }
                 EmptyLayerCause::RestoredLayerAction { cause: None } => {}
             }
             let bin_dir = layer_ref.path().join("bin");
 
-            let agentmon = log_step_timed("Downloading", || {
-                install_agentmon(&bin_dir).map_err(RubyBuildpackError::MetricsAgentError)
-            })?;
+            let agentmon = log_step_timed(
+                format!("Installing metrics agent from {DOWNLOAD_URL}"),
+                || install_agentmon(&bin_dir).map_err(RubyBuildpackError::MetricsAgentError),
+            )?;
 
             log_step("Writing scripts");
             let execd = write_execd_script(&agentmon, layer_ref.path().as_path())

--- a/buildpacks/ruby/src/layers/metrics_agent_install.rs
+++ b/buildpacks/ruby/src/layers/metrics_agent_install.rs
@@ -4,8 +4,7 @@ use flate2::read::GzDecoder;
 use libcnb::additional_buildpack_binary_path;
 use libcnb::data::layer_name;
 use libcnb::layer::{
-    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerRef, LayerState,
-    RestoredLayerAction,
+    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libherokubuildpack::digest::sha256;
 use serde::{Deserialize, Serialize};
@@ -63,7 +62,7 @@ pub(crate) fn handle_metrics_agent_layer(
     // TODO: Replace when implementing bullet_stream. Included with original comment:
     // force the layer to be called within a Section logging context, not necessary but it's safer
     _in_section_logger: &dyn SectionLogger,
-) -> libcnb::Result<LayerRef<RubyBuildpack, (), String>, RubyBuildpackError> {
+) -> libcnb::Result<(), RubyBuildpackError> {
     let layer_ref = context.cached_layer(
         layer_name!("metrics_agent"),
         CachedLayerDefinition {
@@ -117,7 +116,7 @@ pub(crate) fn handle_metrics_agent_layer(
             })?;
         }
     }
-    Ok(layer_ref)
+    Ok(())
 }
 
 fn write_execd_script(

--- a/buildpacks/ruby/src/layers/metrics_agent_install.rs
+++ b/buildpacks/ruby/src/layers/metrics_agent_install.rs
@@ -1,6 +1,6 @@
 use crate::{RubyBuildpack, RubyBuildpackError};
 use bullet_stream::state::SubBullet;
-use bullet_stream::Print;
+use bullet_stream::{style, Print};
 use flate2::read::GzDecoder;
 use libcnb::additional_buildpack_binary_path;
 use libcnb::data::layer_name;
@@ -29,7 +29,7 @@ const DOWNLOAD_URL: &str =
     "https://agentmon-releases.s3.us-east-1.amazonaws.com/agentmon-0.3.1-linux-amd64.tar.gz";
 const DOWNLOAD_SHA: &str = "f9bf9f33c949e15ffed77046ca38f8dae9307b6a0181c6af29a25dec46eb2dac";
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Metadata {
     download_url: String,
 }
@@ -63,22 +63,26 @@ pub(crate) fn handle_metrics_agent_layer(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     mut bullet: Print<SubBullet<Stdout>>,
 ) -> libcnb::Result<Print<SubBullet<Stdout>>, RubyBuildpackError> {
+    let metadata = Metadata {
+        download_url: DOWNLOAD_URL.to_string(),
+    };
+
     let layer_ref = context.cached_layer(
         layer_name!("metrics_agent"),
         CachedLayerDefinition {
             build: true,
             launch: true,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
-            restored_layer_action: &|metadata: &Metadata, _| {
-                if metadata.download_url == DOWNLOAD_URL {
+            restored_layer_action: &|old: &Metadata, _| {
+                if old == &metadata {
                     (
                         RestoredLayerAction::KeepLayer,
-                        metadata.download_url.clone(),
+                        style::url(old.download_url.clone()),
                     )
                 } else {
                     (
                         RestoredLayerAction::DeleteLayer,
-                        metadata.download_url.clone(),
+                        style::url(old.download_url.clone()),
                     )
                 }
             },
@@ -101,9 +105,12 @@ pub(crate) fn handle_metrics_agent_layer(
             }
             let bin_dir = layer_ref.path().join("bin");
 
-            let timer = bullet.start_timer(format!("Installing metrics agent from {DOWNLOAD_URL}"));
-            let agentmon =
-                install_agentmon(&bin_dir).map_err(RubyBuildpackError::MetricsAgentError)?;
+            let timer = bullet.start_timer(format!(
+                "Installing metrics agent from {url}",
+                url = style::url(&metadata.download_url)
+            ));
+            let agentmon = install_agentmon(&bin_dir, &metadata)
+                .map_err(RubyBuildpackError::MetricsAgentError)?;
             bullet = timer.done();
 
             bullet = bullet.sub_bullet("Writing scripts");
@@ -111,9 +118,7 @@ pub(crate) fn handle_metrics_agent_layer(
                 .map_err(RubyBuildpackError::MetricsAgentError)?;
 
             layer_ref.write_exec_d_programs([("spawn_metrics_agent".to_string(), execd)])?;
-            layer_ref.write_metadata(Metadata {
-                download_url: DOWNLOAD_URL.to_string(),
-            })?;
+            layer_ref.write_metadata(metadata)?;
         }
     }
     Ok(bullet)
@@ -162,8 +167,8 @@ fn write_execd_script(
     Ok(execd)
 }
 
-fn install_agentmon(dir: &Path) -> Result<PathBuf, MetricsAgentInstallError> {
-    let agentmon = download_untar(DOWNLOAD_URL, dir).map(|()| dir.join("agentmon"))?;
+fn install_agentmon(dir: &Path, metadata: &Metadata) -> Result<PathBuf, MetricsAgentInstallError> {
+    let agentmon = download_untar(&metadata.download_url, dir).map(|()| dir.join("agentmon"))?;
 
     chmod_plus_x(&agentmon).map_err(MetricsAgentInstallError::PermissionError)?;
     Ok(agentmon)

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -12,6 +12,7 @@ use commons::gemfile_lock::ResolvedRubyVersion;
 use flate2::read::GzDecoder;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::convert::Infallible;
@@ -92,6 +93,7 @@ impl TryFrom<RubyInstallLayerMetadataV1> for RubyInstallLayerMetadataV2 {
     }
 }
 
+#[allow(deprecated)]
 impl<'a> Layer for RubyInstallLayer<'a> {
     type Buildpack = RubyBuildpack;
     type Metadata = RubyInstallLayerMetadata;

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -115,6 +115,7 @@ impl Buildpack for RubyBuildpack {
     }
 
     #[allow(clippy::too_many_lines)]
+    #[allow(deprecated)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let mut logger = BuildLog::new(stdout()).buildpack_name("Heroku Ruby Buildpack");
         let warn_later = WarnGuard::new(stdout());
@@ -131,15 +132,15 @@ impl Buildpack for RubyBuildpack {
         let bundler_version = gemfile_lock.resolve_bundler("2.4.5");
         let ruby_version = gemfile_lock.resolve_ruby("3.1.3");
 
-        let mut build_output = Print::new(stdout()).without_header();
+        let build_output = Print::new(stdout()).without_header();
         // ## Install metrics agent
-        build_output = {
+        _ = {
             let bullet = build_output.bullet("Metrics agent");
             if lockfile_contents.contains("barnes") {
                 layers::metrics_agent_install::handle_metrics_agent_layer(&context, bullet)?.done()
             } else {
                 bullet
-                    .sub_bullet(&format!(
+                    .sub_bullet(format!(
                         "Skipping install ({barnes} gem not found)",
                         barnes = style::value("barnes")
                     ))

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -131,29 +131,21 @@ impl Buildpack for RubyBuildpack {
         let ruby_version = gemfile_lock.resolve_ruby("3.1.3");
 
         // ## Install metrics agent
-        (logger, env) = {
+        logger = {
             let section = logger.section("Metrics agent");
             if lockfile_contents.contains("barnes") {
-                let layer_ref = layers::metrics_agent_install::handle_metrics_agent_layer(
+                layers::metrics_agent_install::handle_metrics_agent_layer(
                     &context,
                     section.as_ref(),
                 )?;
-                (
-                    section.end_section(),
-                    // TODO: This should likely be removed (also eliminating the need for the `handle_metrics_agent_layer` function to return a `LayerRef`)?
-                    // Included the logic here for reference, but it doesn't seem necessary (the layer env isn't explicitly modified as far as I can tell, but perhaps there's some trait API magic happening I'm not familiar with?).
-                    layer_ref.read_env()?.apply(Scope::Build, &env),
-                )
+                section.end_section()
             } else {
-                (
-                    section
-                        .step(&format!(
-                            "Skipping install ({barnes} gem not found)",
-                            barnes = fmt::value("barnes")
-                        ))
-                        .end_section(),
-                    env,
-                )
+                section
+                    .step(&format!(
+                        "Skipping install ({barnes} gem not found)",
+                        barnes = fmt::value("barnes")
+                    ))
+                    .end_section()
             }
         };
 

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -1,3 +1,4 @@
+use bullet_stream::{style, Print};
 use commons::cache::CacheError;
 use commons::gemfile_lock::GemfileLock;
 use commons::metadata_digest::MetadataDigest;
@@ -130,22 +131,19 @@ impl Buildpack for RubyBuildpack {
         let bundler_version = gemfile_lock.resolve_bundler("2.4.5");
         let ruby_version = gemfile_lock.resolve_ruby("3.1.3");
 
+        let mut build_output = Print::new(stdout()).without_header();
         // ## Install metrics agent
-        logger = {
-            let section = logger.section("Metrics agent");
+        build_output = {
+            let bullet = build_output.bullet("Metrics agent");
             if lockfile_contents.contains("barnes") {
-                layers::metrics_agent_install::handle_metrics_agent_layer(
-                    &context,
-                    section.as_ref(),
-                )?;
-                section.end_section()
+                layers::metrics_agent_install::handle_metrics_agent_layer(&context, bullet)?.done()
             } else {
-                section
-                    .step(&format!(
+                bullet
+                    .sub_bullet(&format!(
                         "Skipping install ({barnes} gem not found)",
-                        barnes = fmt::value("barnes")
+                        barnes = style::value("barnes")
                     ))
-                    .end_section()
+                    .done()
             }
         };
 

--- a/buildpacks/ruby/src/steps/default_env.rs
+++ b/buildpacks/ruby/src/steps/default_env.rs
@@ -9,6 +9,7 @@ use libcnb::{
 use rand::Rng;
 
 // Set default environment values
+#[allow(deprecated)]
 pub(crate) fn default_env(
     context: &BuildContext<RubyBuildpack>,
     platform_env: &Env,

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -194,7 +194,7 @@ fn test_barnes_app() {
         |context| {
             println!("{}", context.pack_stdout);
 
-            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            assert_contains!(context.pack_stdout, "Installing metrics agent from https://agentmon-releases.s3.us-east-1.amazonaws.com/agentmon");
             context.start_container(
                 ContainerConfig::new()
                     .entrypoint("launcher")

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -24,7 +24,7 @@ indoc = "2"
 lazy_static = "1"
 # libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
 # so it's pinned to an exact version to isolate it from lockfile refreshes.
-libcnb = "=0.21.0"
+libcnb = "=0.23.0"
 libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["command"] }
 regex = "1"
 serde = "1"

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -236,6 +236,7 @@ pub enum PathState {
 /// # Errors
 ///
 /// - If the layer cannot be created
+#[allow(deprecated)]
 pub fn build<B: libcnb::Buildpack>(
     context: &BuildContext<B>,
     config: CacheConfig,

--- a/commons/src/cache/app_cache_collection.rs
+++ b/commons/src/cache/app_cache_collection.rs
@@ -34,7 +34,7 @@ impl<'a> AppCacheCollection<'a> {
         let caches = config
             .into_iter()
             .map(|config| {
-                AppCache::new_and_load(context, config).map(|store| {
+                AppCache::new_and_load(context, config).inspect(|store| {
                     let path = store.path().display();
 
                     log::log_step(match store.cache_state() {
@@ -42,7 +42,6 @@ impl<'a> AppCacheCollection<'a> {
                         CacheState::ExistsEmpty => format!("Loading (empty) cache for {path}"),
                         CacheState::ExistsWithContents => format!("Loading cache for {path}"),
                     });
-                    store
                 })
             })
             .collect::<Result<Vec<AppCache>, CacheError>>()?;

--- a/commons/src/cache/in_app_dir_cache_layer.rs
+++ b/commons/src/cache/in_app_dir_cache_layer.rs
@@ -1,5 +1,6 @@
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
+#[allow(deprecated)]
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::Buildpack;
 use serde::{Deserialize, Serialize};
@@ -41,6 +42,7 @@ impl<B> InAppDirCacheLayer<B> {
     }
 }
 
+#[allow(deprecated)]
 impl<B> Layer for InAppDirCacheLayer<B>
 where
     B: Buildpack,

--- a/commons/src/layer/configure_env_layer.rs
+++ b/commons/src/layer/configure_env_layer.rs
@@ -1,6 +1,7 @@
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
+#[allow(deprecated)]
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::LayerEnv;
 use std::marker::PhantomData;
@@ -99,6 +100,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<B> Layer for ConfigureEnvLayer<B>
 where
     B: libcnb::Buildpack,


### PR DESCRIPTION
Migrate metrics agent layer to Struct API and bullet Stream. Taking over from #320 with a smaller and more modular process.