### PR TITLE
Shared layer logic for consistent output and unit testing

### DIFF
--- a/buildpacks/ruby/src/layers.rs
+++ b/buildpacks/ruby/src/layers.rs
@@ -2,3 +2,4 @@ pub(crate) mod bundle_download_layer;
 pub(crate) mod bundle_install_layer;
 pub(crate) mod metrics_agent_install;
 pub(crate) mod ruby_install_layer;
+mod shared;

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -327,7 +327,7 @@ version = "3.1.3"
     }
 
     #[test]
-    fn test_ruby_version_difference() {
+    fn test_ruby_version_difference_clears_cache() {
         let old = Metadata {
             ruby_version: ResolvedRubyVersion("2.7.2".to_string()),
             distro_name: "ubuntu".to_string(),
@@ -335,6 +335,12 @@ version = "3.1.3"
             cpu_architecture: "x86_64".to_string(),
         };
         let differences = old.diff(&old);
+        let actual = restored_layer_action(&old, &old);
+        assert!(matches!(
+            actual,
+            (libcnb::layer::RestoredLayerAction::KeepLayer, _)
+        ));
+
         assert_eq!(differences, Vec::<String>::new());
 
         let now = Metadata {
@@ -342,14 +348,10 @@ version = "3.1.3"
             ..old.clone()
         };
 
-        let differences = now.diff(&old);
-        assert_eq!(
-            differences,
-            vec![format!(
-                "Ruby version ({old} to {now})",
-                old = style::value("2.7.2"),
-                now = style::value("3.0.0")
-            )]
-        );
+        let actual = restored_layer_action(&old, &now);
+        assert!(matches!(
+            actual,
+            (libcnb::layer::RestoredLayerAction::DeleteLayer, _)
+        ));
     }
 }

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -325,4 +325,31 @@ version = "3.1.3"
             "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-22/ruby-2.7.4.tgz",
         );
     }
+
+    #[test]
+    fn test_ruby_version_difference() {
+        let old = Metadata {
+            ruby_version: ResolvedRubyVersion("2.7.2".to_string()),
+            distro_name: "ubuntu".to_string(),
+            distro_version: "20.04".to_string(),
+            cpu_architecture: "x86_64".to_string(),
+        };
+        let differences = old.diff(&old);
+        assert_eq!(differences, Vec::<String>::new());
+
+        let now = Metadata {
+            ruby_version: ResolvedRubyVersion("3.0.0".to_string()),
+            ..old.clone()
+        };
+
+        let differences = now.diff(&old);
+        assert_eq!(
+            differences,
+            vec![format!(
+                "Ruby version ({old} to {now})",
+                old = style::value("2.7.2"),
+                now = style::value("3.0.0")
+            )]
+        );
+    }
 }

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -144,8 +144,9 @@ impl MetadataDiff for Metadata {
         }
         if distro_name != &self.distro_name || distro_version != &self.distro_version {
             differences.push(format!(
-                "Distribution ({} {} to {} {})",
-                distro_name, distro_version, self.distro_name, self.distro_version
+                "Distribution ({old} to {now})",
+                old = style::value(format!("{distro_name} {distro_version}")),
+                now = style::value(format!("{} {}", self.distro_name, self.distro_version))
             ));
         }
         if cpu_architecture != &self.cpu_architecture {

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -11,7 +11,7 @@
 //!
 //! When the Ruby version changes, invalidate and re-run.
 //!
-use crate::layers::shared::{invalid_metadata_action, MetadataDiff};
+use crate::layers::shared::{invalid_metadata_action, restored_layer_action, MetadataDiff};
 use crate::{
     target_id::{TargetId, TargetIdError},
     RubyBuildpack, RubyBuildpackError,
@@ -46,24 +46,7 @@ pub(crate) fn handle(
             build: true,
             launch: true,
             invalid_metadata_action: &invalid_metadata_action,
-            restored_layer_action: &|old: &Metadata, _| {
-                let diff = metadata.diff(old);
-                if diff.is_empty() {
-                    (
-                        RestoredLayerAction::KeepLayer,
-                        "using cached version".to_string(),
-                    )
-                } else {
-                    (
-                        RestoredLayerAction::DeleteLayer,
-                        format!(
-                            "due to {changes}: {differences}",
-                            changes = if diff.len() > 1 { "changes" } else { "change" },
-                            differences = SentenceList::new(&diff)
-                        ),
-                    )
-                }
-            },
+            restored_layer_action: &|old: &Metadata, _| restored_layer_action(old, &metadata),
         },
     )?;
     match &layer_ref.state {

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -11,7 +11,9 @@
 //!
 //! When the Ruby version changes, invalidate and re-run.
 //!
-use crate::layers::shared::{invalid_metadata_action, restored_layer_action, MetadataDiff};
+use crate::layers::shared::{
+    cached_layer_ref, invalid_metadata_action, restored_layer_action, MetadataDiff,
+};
 use crate::{
     target_id::{TargetId, TargetIdError},
     RubyBuildpack, RubyBuildpackError,
@@ -40,15 +42,7 @@ pub(crate) fn handle(
     mut bullet: Print<SubBullet<Stdout>>,
     metadata: Metadata,
 ) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
-    let layer_ref = context.cached_layer(
-        layer_name!("ruby"),
-        CachedLayerDefinition {
-            build: true,
-            launch: true,
-            invalid_metadata_action: &invalid_metadata_action,
-            restored_layer_action: &|old: &Metadata, _| restored_layer_action(old, &metadata),
-        },
-    )?;
+    let layer_ref = cached_layer_ref(layer_name!("ruby"), context, &metadata)?;
     match &layer_ref.state {
         LayerState::Restored { cause: _ } => {
             bullet = bullet.sub_bullet("Using cached Ruby version");

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -12,7 +12,7 @@
 //! When the Ruby version changes, invalidate and re-run.
 //!
 use crate::layers::shared::{
-    cached_layer_ref, invalid_metadata_action, restored_layer_action, MetadataDiff,
+    cached_layer_write_metadata, invalid_metadata_action, restored_layer_action, MetadataDiff,
 };
 use crate::{
     target_id::{TargetId, TargetIdError},
@@ -42,7 +42,7 @@ pub(crate) fn handle(
     mut bullet: Print<SubBullet<Stdout>>,
     metadata: Metadata,
 ) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
-    let layer_ref = cached_layer_ref(layer_name!("ruby"), context, &metadata)?;
+    let layer_ref = cached_layer_write_metadata(layer_name!("ruby"), context, &metadata)?;
     match &layer_ref.state {
         LayerState::Restored { cause: _ } => {
             bullet = bullet.sub_bullet("Using cached Ruby version");
@@ -60,7 +60,6 @@ pub(crate) fn handle(
             bullet = timer.done();
         }
     }
-    layer_ref.write_metadata(metadata)?;
     Ok((bullet, layer_ref.read_env()?))
 }
 

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -142,18 +142,10 @@ impl MetadataDiff for Metadata {
                 now = style::value(self.ruby_version.to_string())
             ));
         }
-        if distro_name != &self.distro_name {
+        if distro_name != &self.distro_name || distro_version != &self.distro_version {
             differences.push(format!(
-                "distro name ({old} to {now})",
-                old = style::value(distro_name),
-                now = style::value(&self.distro_name)
-            ));
-        }
-        if distro_version != &self.distro_version {
-            differences.push(format!(
-                "distro version ({old} to {now})",
-                old = style::value(distro_version),
-                now = style::value(&self.distro_version)
+                "Distribution ({} {} to {} {})",
+                distro_name, distro_version, self.distro_name, self.distro_version
             ));
         }
         if cpu_architecture != &self.cpu_architecture {

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -40,9 +40,9 @@ use url::Url;
 pub(crate) fn handle(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     mut bullet: Print<SubBullet<Stdout>>,
-    metadata: Metadata,
+    metadata: &Metadata,
 ) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
-    let layer_ref = cached_layer_write_metadata(layer_name!("ruby"), context, &metadata)?;
+    let layer_ref = cached_layer_write_metadata(layer_name!("ruby"), context, metadata)?;
     match &layer_ref.state {
         LayerState::Restored { cause: _ } => {
             bullet = bullet.sub_bullet("Using cached Ruby version");
@@ -56,7 +56,7 @@ pub(crate) fn handle(
                 }
             }
             let timer = bullet.start_timer("Installing");
-            install_ruby(&metadata, &layer_ref.path())?;
+            install_ruby(metadata, &layer_ref.path())?;
             bullet = timer.done();
         }
     }

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -11,7 +11,7 @@
 //!
 //! When the Ruby version changes, invalidate and re-run.
 //!
-use crate::layers::shared::MetadataDiff;
+use crate::layers::shared::{invalid_metadata_action, MetadataDiff};
 use crate::{
     target_id::{TargetId, TargetIdError},
     RubyBuildpack, RubyBuildpackError,
@@ -45,22 +45,7 @@ pub(crate) fn handle(
         CachedLayerDefinition {
             build: true,
             launch: true,
-            invalid_metadata_action: &|old| match Metadata::try_from_str_migrations(
-                &toml::to_string(old).expect("TOML deserialization of GenericMetadata"),
-            ) {
-                Some(Ok(migrated)) => (
-                    InvalidMetadataAction::ReplaceMetadata(migrated),
-                    "replaced metadata".to_string(),
-                ),
-                Some(Err(error)) => (
-                    InvalidMetadataAction::DeleteLayer,
-                    format!("metadata migration error {error}"),
-                ),
-                None => (
-                    InvalidMetadataAction::DeleteLayer,
-                    "invalid metadata".to_string(),
-                ),
-            },
+            invalid_metadata_action: &invalid_metadata_action,
             restored_layer_action: &|old: &Metadata, _| {
                 let diff = metadata.diff(old);
                 if diff.is_empty() {

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -39,15 +39,15 @@ pub(crate) fn handle(
 ) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
     let layer_ref = cached_layer_write_metadata(layer_name!("ruby"), context, metadata)?;
     match &layer_ref.state {
-        LayerState::Restored { cause: _ } => {
-            bullet = bullet.sub_bullet("Using cached Ruby version");
+        LayerState::Restored { cause } => {
+            bullet = bullet.sub_bullet(cause);
         }
         LayerState::Empty { cause } => {
             match cause {
                 EmptyLayerCause::NewlyCreated => {}
                 EmptyLayerCause::InvalidMetadataAction { cause }
                 | EmptyLayerCause::RestoredLayerAction { cause } => {
-                    bullet = bullet.sub_bullet(format!("Clearing cache {cause}"));
+                    bullet = bullet.sub_bullet(cause);
                 }
             }
             let timer = bullet.start_timer("Installing");

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -11,22 +11,21 @@
 //!
 //! When the Ruby version changes, invalidate and re-run.
 //!
+use crate::{
+    target_id::{TargetId, TargetIdError},
+    RubyBuildpack, RubyBuildpackError,
+};
 use bullet_stream::state::SubBullet;
 use bullet_stream::{style, Print};
 use commons::display::SentenceList;
+use commons::gemfile_lock::ResolvedRubyVersion;
+use flate2::read::GzDecoder;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::LayerEnv;
 use magic_migrate::{try_migrate_deserializer_chain, TryMigrate};
-
-use crate::{
-    target_id::{TargetId, TargetIdError},
-    RubyBuildpack, RubyBuildpackError,
-};
-use commons::gemfile_lock::ResolvedRubyVersion;
-use flate2::read::GzDecoder;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::convert::Infallible;
 use std::io::{self, Stdout};

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -11,22 +11,17 @@
 //!
 //! When the Ruby version changes, invalidate and re-run.
 //!
-use crate::layers::shared::{
-    cached_layer_write_metadata, invalid_metadata_action, restored_layer_action, MetadataDiff,
-};
+use crate::layers::shared::{cached_layer_write_metadata, MetadataDiff};
 use crate::{
     target_id::{TargetId, TargetIdError},
     RubyBuildpack, RubyBuildpackError,
 };
 use bullet_stream::state::SubBullet;
 use bullet_stream::{style, Print};
-use commons::display::SentenceList;
 use commons::gemfile_lock::ResolvedRubyVersion;
 use flate2::read::GzDecoder;
 use libcnb::data::layer_name;
-use libcnb::layer::{
-    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
-};
+use libcnb::layer::{EmptyLayerCause, LayerState};
 use libcnb::layer_env::LayerEnv;
 use magic_migrate::{try_migrate_deserializer_chain, TryMigrate};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -254,6 +249,8 @@ pub(crate) enum RubyInstallError {
 
 #[cfg(test)]
 mod tests {
+    use crate::layers::shared::restored_layer_action;
+
     use super::*;
 
     /// If this test fails due to a change you'll need to

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -1,10 +1,34 @@
-use libcnb::layer::InvalidMetadataAction;
+use commons::display::SentenceList;
+use libcnb::layer::{InvalidMetadataAction, RestoredLayerAction};
 
 /// Given another metadata object, returns a list of differences between the two
 ///
 /// If no differences, return an empty list
 pub(crate) trait MetadataDiff {
     fn diff(&self, old: &Self) -> Vec<String>;
+}
+
+/// Standardizes formatting for layer cache clearing behavior
+///
+/// If the diff is empty, there are no changes and the layer is kept
+/// If the diff is not empty, the layer is deleted and the changes are listed
+pub(crate) fn restored_layer_action<T>(old: &T, now: &T) -> (RestoredLayerAction, String)
+where
+    T: MetadataDiff,
+{
+    let diff = now.diff(old);
+    if diff.is_empty() {
+        (RestoredLayerAction::KeepLayer, "Using cache".to_string())
+    } else {
+        (
+            RestoredLayerAction::DeleteLayer,
+            format!(
+                "Clearing cache due to {changes}: {differences}",
+                changes = if diff.len() > 1 { "changes" } else { "change" },
+                differences = SentenceList::new(&diff)
+            ),
+        )
+    }
 }
 
 /// Standardizes formatting for invalid metadata behavior

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -97,6 +97,13 @@ where
     }
 }
 
+/// Removes ANSI control characters from a string
+#[cfg(test)]
+pub(crate) fn strip_ansi(input: impl AsRef<str>) -> String {
+    let re = regex::Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").expect("Clippy checked");
+    re.replace_all(input.as_ref(), "").to_string()
+}
+
 /// Takes in a directory and returns a minimal build context for use in testing shared caching behavior
 ///
 /// Intented only for use with this buildpack, but meant to be used by multiple layers to assert caching behavior.

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -1,0 +1,6 @@
+/// Given another metadata object, returns a list of differences between the two
+///
+/// If no differences, return an empty list
+pub(crate) trait MetadataDiff {
+    fn diff(&self, old: &Self) -> Vec<String>;
+}

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -1,6 +1,38 @@
+use libcnb::layer::InvalidMetadataAction;
+
 /// Given another metadata object, returns a list of differences between the two
 ///
 /// If no differences, return an empty list
 pub(crate) trait MetadataDiff {
     fn diff(&self, old: &Self) -> Vec<String>;
+}
+
+/// Standardizes formatting for invalid metadata behavior
+///
+/// If the metadata can be migrated, it is replaced with the migrated version
+/// If an error occurs, the layer is deleted and the error displayed
+/// If no migration is possible, the layer is deleted and the invalid metadata is displayed
+pub(crate) fn invalid_metadata_action<T, S>(invalid: &S) -> (InvalidMetadataAction<T>, String)
+where
+    T: magic_migrate::TryMigrate,
+    S: serde::ser::Serialize + std::fmt::Debug,
+    // TODO: Enforce Display + Debug in the library
+    <T as magic_migrate::TryMigrate>::Error: std::fmt::Display,
+{
+    match T::try_from_str_migrations(
+        &toml::to_string(invalid).expect("TOML deserialization of GenericMetadata"),
+    ) {
+        Some(Ok(migrated)) => (
+            InvalidMetadataAction::ReplaceMetadata(migrated),
+            "Replaced metadata".to_string(),
+        ),
+        Some(Err(error)) => (
+            InvalidMetadataAction::DeleteLayer,
+            format!("Clearing cache due to metadata migration error: {error}"),
+        ),
+        None => (
+            InvalidMetadataAction::DeleteLayer,
+            format!("Clearing cache due to invalid metadata ({invalid:?})"),
+        ),
+    }
 }

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -93,3 +93,132 @@ where
         ),
     }
 }
+
+/// Takes in a directory and returns a minimal build context for use in testing shared caching behavior
+///
+/// Intented only for use with this buildpack, but meant to be used by multiple layers to assert caching behavior.
+#[cfg(test)]
+pub(crate) fn temp_build_context<B: libcnb::Buildpack>(
+    from_dir: impl AsRef<std::path::Path>,
+) -> BuildContext<B> {
+    let base_dir = from_dir.as_ref().to_path_buf();
+    let layers_dir = base_dir.join("layers");
+    let app_dir = base_dir.join("app_dir");
+    let platform_dir = base_dir.join("platform_dir");
+    let buildpack_dir = base_dir.join("buildpack_dir");
+    for dir in [&app_dir, &layers_dir, &buildpack_dir, &platform_dir] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+
+    let target = libcnb::Target {
+        os: String::new(),
+        arch: String::new(),
+        arch_variant: None,
+        distro_name: String::new(),
+        distro_version: String::new(),
+    };
+    let buildpack_toml_string = include_str!("../../buildpack.toml");
+    let platform =
+        <<B as libcnb::Buildpack>::Platform as libcnb::Platform>::from_path(&platform_dir).unwrap();
+    let buildpack_descriptor: libcnb::data::buildpack::ComponentBuildpackDescriptor<
+        <B as libcnb::Buildpack>::Metadata,
+    > = toml::from_str(buildpack_toml_string).unwrap();
+    let buildpack_plan = libcnb::data::buildpack_plan::BuildpackPlan {
+        entries: Vec::<libcnb::data::buildpack_plan::Entry>::new(),
+    };
+    let store = None;
+
+    BuildContext {
+        layers_dir,
+        app_dir,
+        buildpack_dir,
+        target,
+        platform,
+        buildpack_plan,
+        buildpack_descriptor,
+        store,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RubyBuildpack;
+    use libcnb::data::layer_name;
+    use libcnb::layer::{EmptyLayerCause, LayerState};
+    use magic_migrate::{migrate_toml_chain, Migrate};
+    use serde::Deserializer;
+
+    /// Struct for asserting the behavior of `cached_layer_write_metadata`
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    struct TestMetadata {
+        value: String,
+    }
+    impl MetadataDiff for TestMetadata {
+        fn diff(&self, old: &Self) -> Vec<String> {
+            if self.value == old.value {
+                vec![]
+            } else {
+                vec![format!("value ({} to {})", old.value, self.value)]
+            }
+        }
+    }
+    migrate_toml_chain! {TestMetadata}
+
+    #[test]
+    fn test_cached_layer_write_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let context = temp_build_context::<RubyBuildpack>(temp.path());
+
+        // First write
+        let result = cached_layer_write_metadata(
+            layer_name!("testing"),
+            &context,
+            &TestMetadata {
+                value: "hello".to_string(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            result.state,
+            LayerState::Empty {
+                cause: EmptyLayerCause::NewlyCreated
+            }
+        ));
+
+        // Second write, preserve the contents
+        let result = cached_layer_write_metadata(
+            layer_name!("testing"),
+            &context,
+            &TestMetadata {
+                value: "hello".to_string(),
+            },
+        )
+        .unwrap();
+        let LayerState::Restored { cause } = &result.state else {
+            panic!("Expected restored layer")
+        };
+        assert_eq!(cause, "Using cache");
+
+        // Third write, change the data
+        let result = cached_layer_write_metadata(
+            layer_name!("testing"),
+            &context,
+            &TestMetadata {
+                value: "world".to_string(),
+            },
+        )
+        .unwrap();
+
+        let LayerState::Empty {
+            cause: EmptyLayerCause::RestoredLayerAction { cause },
+        } = &result.state
+        else {
+            panic!("Expected empty layer with restored layer action");
+        };
+        assert_eq!(
+            cause,
+            "Clearing cache due to change: value (hello to world)"
+        );
+    }
+}

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -158,7 +158,7 @@ impl Buildpack for RubyBuildpack {
             let (bullet, layer_env) = layers::ruby_install_layer::handle(
                 &context,
                 bullet,
-                layers::ruby_install_layer::Metadata {
+                &layers::ruby_install_layer::Metadata {
                     distro_name: context.target.distro_name.clone(),
                     distro_version: context.target.distro_version.clone(),
                     cpu_architecture: context.target.arch.clone(),


### PR DESCRIPTION
PR #326 pointed out inconsistencies in the style of output for different layers and asked for additional tests. This refactor makes that request easier by introducing shared logic for invalid metadata and cache invalidation.

It's a ducktyping approach based on two traits:

- `magic_migrate::TryMigrate` provides an interface to (possibly) migrate invalid metadata or display errors
- `MetadataDiff` provides an interface to allow standardize cache invalidation and restoration logic

These allow me to remove the bulk of cache invalidation logic into a central shared location. They also expose a clean interface for unit testing cache invalidation logic, which can then be used on other layers.

I described some of the background desires in #325, comment: https://github.com/heroku/buildpacks-ruby/pull/325#discussion_r1773558240. 