### PR TITLE
Move bundle download to struct API and bullet stream

### DIFF
--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -18,13 +18,27 @@ use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Env;
-use serde::{Deserialize, Serialize};
+use magic_migrate::{try_migrate_deserializer_chain, TryMigrate};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::convert::Infallible;
 use std::path::Path;
 use std::process::Command;
 
+pub(crate) type Metadata = MetadataV1;
+try_migrate_deserializer_chain!(
+    deserializer: toml::Deserializer::new,
+    error: MetadataError,
+    chain: [MetadataV1],
+);
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub(crate) struct Metadata {
+pub(crate) struct MetadataV1 {
     pub(crate) version: ResolvedBundlerVersion,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MetadataError {
+    // Update if migrating between a metadata version can error
 }
 
 pub(crate) struct BundleDownloadLayer<'a> {

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -72,24 +72,16 @@ fn download_bundler(
     let gem_path = path;
 
     let mut cmd = Command::new("gem");
-    cmd.args([
-        "install",
-        "bundler",
-        "--version", // Specify exact version to install
-        &metadata.version.to_string(),
-    ])
-    .env_clear()
-    .envs(env);
+    cmd.args(["install", "bundler"]);
+    cmd.args(["--version", &metadata.version.to_string()]) // Specify exact version to install
+        .env_clear()
+        .envs(env);
 
-    // Format `gem install --version <version>` without other content for display
-    let short_name = fun_run::display(&mut cmd);
+    let short_name = fun_run::display(&mut cmd); // Format `gem install --version <version>` without other content for display
 
-    // Arguments we don't need in the output
+    cmd.args(["--install-dir", &format!("{}", gem_path.display())]); // Directory where bundler's contents will live
+    cmd.args(["--bindir", &format!("{}", bin_dir.display())]); // Directory where `bundle` executable lives
     cmd.args([
-        "--install-dir", // Directory where bundler's contents will live
-        &gem_path.to_string_lossy(),
-        "--bindir", // Directory where `bundle` executable lives
-        &bin_dir.to_string_lossy(),
         "--force",       // Overwrite if it already exists
         "--no-document", // Don't install ri or rdoc documentation, which takes extra time
         "--env-shebang", // Start the `bundle` executable with `#! /usr/bin/env ruby`

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -23,20 +23,20 @@ use std::path::Path;
 use std::process::Command;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub(crate) struct BundleDownloadLayerMetadata {
+pub(crate) struct Metadata {
     pub(crate) version: ResolvedBundlerVersion,
 }
 
 pub(crate) struct BundleDownloadLayer<'a> {
     pub(crate) env: Env,
-    pub(crate) metadata: BundleDownloadLayerMetadata,
+    pub(crate) metadata: Metadata,
     pub(crate) _section_logger: &'a dyn SectionLogger,
 }
 
 #[allow(deprecated)]
 impl<'a> Layer for BundleDownloadLayer<'a> {
     type Buildpack = RubyBuildpack;
-    type Metadata = BundleDownloadLayerMetadata;
+    type Metadata = Metadata;
 
     fn types(&self) -> LayerTypes {
         LayerTypes {
@@ -137,8 +137,8 @@ enum State {
     BundlerVersionChanged(ResolvedBundlerVersion, ResolvedBundlerVersion),
 }
 
-fn cache_state(old: BundleDownloadLayerMetadata, now: BundleDownloadLayerMetadata) -> State {
-    let BundleDownloadLayerMetadata { version } = now; // Ensure all properties are checked
+fn cache_state(old: Metadata, now: Metadata) -> State {
+    let Metadata { version } = now; // Ensure all properties are checked
 
     if old.version == version {
         State::NothingChanged(version)
@@ -155,7 +155,7 @@ mod test {
     /// `migrate_incompatible_metadata` for the Layer trait
     #[test]
     fn metadata_guard() {
-        let metadata = BundleDownloadLayerMetadata {
+        let metadata = Metadata {
             version: ResolvedBundlerVersion(String::from("2.3.6")),
         };
 

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -1,3 +1,9 @@
+//! # Install the bundler gem
+//!
+//! ## Layer dir: Install bundler to disk
+//!
+//! Installs a copy of `bundler` to the `<layer-dir>` with a bundler executable in
+//! `<layer-dir>/bin`. Must run before [`crate.steps.bundle_install`].
 use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
 use commons::gemfile_lock::ResolvedBundlerVersion;
@@ -21,12 +27,6 @@ pub(crate) struct BundleDownloadLayerMetadata {
     pub(crate) version: ResolvedBundlerVersion,
 }
 
-/// # Install the bundler gem
-///
-/// ## Layer dir: Install bundler to disk
-///
-/// Installs a copy of `bundler` to the `<layer-dir>` with a bundler executable in
-/// `<layer-dir>/bin`. Must run before [`crate.steps.bundle_install`].
 pub(crate) struct BundleDownloadLayer<'a> {
     pub(crate) env: Env,
     pub(crate) metadata: BundleDownloadLayerMetadata,

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -10,10 +10,10 @@ pub(crate) fn cached_layer_write_metadata<M, B>(
     layer_name: libcnb::data::layer::LayerName,
     context: &BuildContext<B>,
     metadata: &'_ M,
-) -> libcnb::Result<LayerRef<B, String, String>, B::Error>
+) -> libcnb::Result<LayerRef<B, Meta<M>, Meta<M>>, B::Error>
 where
     B: libcnb::Buildpack,
-    M: MetadataDiff + magic_migrate::TryMigrate + serde::ser::Serialize + std::fmt::Debug,
+    M: MetadataDiff + magic_migrate::TryMigrate + serde::ser::Serialize + std::fmt::Debug + Clone,
     <M as magic_migrate::TryMigrate>::Error: std::fmt::Display,
 {
     let layer_ref = context.cached_layer(
@@ -40,21 +40,21 @@ pub(crate) trait MetadataDiff {
 ///
 /// If the diff is empty, there are no changes and the layer is kept
 /// If the diff is not empty, the layer is deleted and the changes are listed
-pub(crate) fn restored_layer_action<T>(old: &T, now: &T) -> (RestoredLayerAction, String)
+pub(crate) fn restored_layer_action<M>(old: &M, now: &M) -> (RestoredLayerAction, Meta<M>)
 where
-    T: MetadataDiff,
+    M: MetadataDiff + Clone,
 {
     let diff = now.diff(old);
     if diff.is_empty() {
-        (RestoredLayerAction::KeepLayer, "Using cache".to_string())
+        (RestoredLayerAction::KeepLayer, Meta::Data(now.clone()))
     } else {
         (
             RestoredLayerAction::DeleteLayer,
-            format!(
+            Meta::Message(format!(
                 "Clearing cache due to {changes}: {differences}",
                 changes = if diff.len() > 1 { "changes" } else { "change" },
                 differences = SentenceList::new(&diff)
-            ),
+            )),
         )
     }
 }
@@ -64,36 +64,80 @@ where
 /// If the metadata can be migrated, it is replaced with the migrated version
 /// If an error occurs, the layer is deleted and the error displayed
 /// If no migration is possible, the layer is deleted and the invalid metadata is displayed
-pub(crate) fn invalid_metadata_action<T, S>(invalid: &S) -> (InvalidMetadataAction<T>, String)
+pub(crate) fn invalid_metadata_action<M, S>(invalid: &S) -> (InvalidMetadataAction<M>, Meta<M>)
 where
-    T: magic_migrate::TryMigrate,
+    M: magic_migrate::TryMigrate + Clone,
     S: serde::ser::Serialize + std::fmt::Debug,
     // TODO: Enforce Display + Debug in the library
-    <T as magic_migrate::TryMigrate>::Error: std::fmt::Display,
+    <M as magic_migrate::TryMigrate>::Error: std::fmt::Display,
 {
     let invalid = toml::to_string(invalid);
     match invalid {
-        Ok(toml) => match T::try_from_str_migrations(&toml) {
+        Ok(toml) => match M::try_from_str_migrations(&toml) {
             Some(Ok(migrated)) => (
-                InvalidMetadataAction::ReplaceMetadata(migrated),
-                "Replaced metadata".to_string(),
+                InvalidMetadataAction::ReplaceMetadata(migrated.clone()),
+                Meta::Data(migrated),
             ),
             Some(Err(error)) => (
                 InvalidMetadataAction::DeleteLayer,
-                format!("Clearing cache due to metadata migration error: {error}"),
+                Meta::Message(format!(
+                    "Clearing cache due to metadata migration error: {error}"
+                )),
             ),
             None => (
                 InvalidMetadataAction::DeleteLayer,
-                format!(
+                Meta::Message(format!(
                     "Clearing cache due to invalid metadata ({toml})",
                     toml = toml.trim()
-                ),
+                )),
             ),
         },
         Err(error) => (
             InvalidMetadataAction::DeleteLayer,
-            format!("Clearing cache due to invalid metadata serialization error: {error}"),
+            Meta::Message(format!(
+                "Clearing cache due to invalid metadata serialization error: {error}"
+            )),
         ),
+    }
+}
+
+/// Either contains metadata or a message describing the state
+///
+/// Why: The `CachedLayerDefinition` allows returning information about the cache state
+/// from either `invalid_metadata_action` or `restored_layer_action` functions.
+///
+/// Because the function returns only a single type, that type must be the same for
+/// all possible cache conditions (cleared or retained). Therefore, the type must be
+/// able to represent information about the cache state when it's cleared or not.
+///
+/// This struct implements `Display` and `AsRef<str>` so if the end user only
+/// wants to advertise the cache state, they can do so by passing the whole struct
+/// to `format!` or `println!` without any further maniuplation. If they need
+/// to inspect the previous metadata they can match on the enum and extract
+/// what they need.
+///
+/// - Will only ever contain metadata when the cache is retained.
+/// - Will contain a message when the cache is cleared, describing why it was cleared.
+///   It is also allowable to return a message when the cache is retained, and the
+///   message describes the state of the cache. (i.e. because a message is returned
+///   does not guarantee the cache was cleared).
+pub(crate) enum Meta<M> {
+    Message(String),
+    Data(M),
+}
+
+impl<M> std::fmt::Display for Meta<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+impl<M> AsRef<str> for Meta<M> {
+    fn as_ref(&self) -> &str {
+        match self {
+            Meta::Message(s) => s.as_str(),
+            Meta::Data(_) => "Using cache",
+        }
     }
 }
 
@@ -162,7 +206,7 @@ mod tests {
     use std::convert::Infallible;
 
     /// Struct for asserting the behavior of `cached_layer_write_metadata`
-    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
     struct TestMetadata {
         value: String,
     }
@@ -210,7 +254,7 @@ mod tests {
         let LayerState::Restored { cause } = &result.state else {
             panic!("Expected restored layer")
         };
-        assert_eq!(cause, "Using cache");
+        assert_eq!(cause.as_ref(), "Using cache");
 
         // Third write, change the data
         let result = cached_layer_write_metadata(
@@ -229,19 +273,19 @@ mod tests {
             panic!("Expected empty layer with restored layer action");
         };
         assert_eq!(
-            cause,
+            cause.as_ref(),
             "Clearing cache due to change: value (hello to world)"
         );
     }
 
     /// Struct for asserting the behavior of `invalid_metadata_action`
-    #[derive(serde::Deserialize, serde::Serialize, Debug)]
+    #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
     #[serde(deny_unknown_fields)]
     struct PersonV1 {
         name: String,
     }
     /// Struct for asserting the behavior of `invalid_metadata_action`
-    #[derive(serde::Deserialize, serde::Serialize, Debug)]
+    #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
     #[serde(deny_unknown_fields)]
     struct PersonV2 {
         name: String,
@@ -289,15 +333,15 @@ mod tests {
             name: "schneems".to_string(),
         });
         assert!(matches!(action, InvalidMetadataAction::ReplaceMetadata(_)));
-        assert_eq!(message, "Replaced metadata".to_string());
+        assert_eq!(message.as_ref(), "Using cache");
 
         let (action, message) = invalid_metadata_action::<PersonV2, _>(&PersonV1 {
             name: "not_richard".to_string(),
         });
         assert!(matches!(action, InvalidMetadataAction::DeleteLayer));
         assert_eq!(
-            message,
-            "Clearing cache due to metadata migration error: Not Richard".to_string()
+            message.as_ref(),
+            "Clearing cache due to metadata migration error: Not Richard"
         );
 
         let (action, message) = invalid_metadata_action::<PersonV2, _>(&TestMetadata {
@@ -305,10 +349,9 @@ mod tests {
         });
         assert!(matches!(action, InvalidMetadataAction::DeleteLayer));
         assert_eq!(
-            message,
-            "Clearing cache due to invalid metadata (value = \"world\")".to_string()
+            message.as_ref(),
+            "Clearing cache due to invalid metadata (value = \"world\")"
         );
-
         // Unable to produce this error at will: "Clearing cache due to invalid metadata serialization error: {error}"
     }
 }

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 use fs_err::PathExt;
 use fun_run::CmdError;
 use layers::{
-    bundle_download_layer::{BundleDownloadLayer, BundleDownloadLayerMetadata},
+    bundle_download_layer::BundleDownloadLayer,
     bundle_install_layer::{BundleInstallLayer, BundleInstallLayerMetadata},
     metrics_agent_install::MetricsAgentInstallError,
     ruby_install_layer::RubyInstallError,
@@ -180,7 +180,7 @@ impl Buildpack for RubyBuildpack {
                 layer_name!("bundler"),
                 BundleDownloadLayer {
                     env: env.clone(),
-                    metadata: BundleDownloadLayerMetadata {
+                    metadata: layers::bundle_download_layer::Metadata {
                         version: bundler_version,
                     },
                     _section_logger: section.as_ref(),


### PR DESCRIPTION
Details in commits. The handle layer caching logic is exactly the same as the Ruby install layer https://github.com/heroku/buildpacks-ruby/blob/ec57995644a5feb3a89558918551373dc8d3541b/buildpacks/ruby/src/layers/ruby_install_layer.rs#L40-L58