### PR TITLE
Close #302 Preserve mtime when copying to/from the cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "ascii_table",
  "byte-unit",
  "const_format",
+ "cp_r",
  "fancy-regex",
  "filetime",
  "fs-err",
@@ -320,6 +321,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "cp_r"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "837ca07dfd27a2663ac7c4701bb35856b534c2a61dd47af06ccf65d3bec79ebc"
+dependencies = [
+ "filetime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,6 @@ dependencies = [
  "fancy-regex",
  "filetime",
  "fs-err",
- "fs_extra",
  "fun_run",
  "glob",
  "indoc",

--- a/commons/CHANGELOG.md
+++ b/commons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for commons features
 
+## 2024-08-16
+
+### Fixed
+
+- `AppCache` will now preserve mtime of files when copying them to/from the cache (https://github.com/heroku/buildpacks-ruby/pull/336)
+
 ## 2024-08-15
 
 ### Changed

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -16,7 +16,6 @@ byte-unit = "5"
 const_format = "0.2"
 # TODO: Consolidate on either the regex crate or the fancy-regex crate, since this repo currently uses both.
 fancy-regex = "0.13"
-fs_extra = "1"
 fs-err = "2"
 fun_run = "0.2"
 glob = "0.3"

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = "0.10"
 tempfile = "3"
 thiserror = "1"
 walkdir = "2"
+cp_r = "0.5.2"
 
 [dev-dependencies]
 filetime = "0.2"

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -388,6 +388,31 @@ mod tests {
     }
 
     #[test]
+    fn test_load_does_not_clobber_files() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let cache_path = tmpdir.path().join("cache");
+        let app_path = tmpdir.path().join("app");
+        fs_err::create_dir_all(&cache_path).unwrap();
+        fs_err::create_dir_all(&app_path).unwrap();
+
+        fs_err::write(app_path.join("a.txt"), "app").unwrap();
+        fs_err::write(cache_path.join("a.txt"), "cache").unwrap();
+
+        let store = AppCache {
+            path: app_path.clone(),
+            cache: cache_path,
+            limit: Byte::from_u64(512),
+            keep_path: KeepPath::Runtime,
+            cache_state: CacheState::NewEmpty,
+        };
+
+        store.load().unwrap();
+
+        let contents = fs_err::read_to_string(app_path.join("a.txt")).unwrap();
+        assert_eq!("app", contents);
+    }
+
+    #[test]
     fn test_copying_back_to_cache() {
         let tmpdir = tempfile::tempdir().unwrap();
         let cache_path = tmpdir.path().join("cache");

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -388,6 +388,27 @@ mod tests {
     }
 
     #[test]
+    fn test_layer_name_cache_state() {
+        let layer_name = layer_name!("name");
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path();
+        assert_eq!(
+            CacheState::NewEmpty,
+            layer_name_cache_state(path, &layer_name)
+        );
+        fs_err::create_dir_all(path.join(layer_name.as_str())).unwrap();
+        assert_eq!(
+            CacheState::ExistsEmpty,
+            layer_name_cache_state(path, &layer_name)
+        );
+        fs_err::write(path.join(layer_name.as_str()).join("file"), "data").unwrap();
+        assert_eq!(
+            CacheState::ExistsWithContents,
+            layer_name_cache_state(path, &layer_name)
+        );
+    }
+
+    #[test]
     fn test_load_does_not_clobber_files() {
         let tmpdir = tempfile::tempdir().unwrap();
         let cache_path = tmpdir.path().join("cache");

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -2,7 +2,6 @@ use crate::cache::clean::{lru_clean, FilesWithSize};
 use crate::cache::in_app_dir_cache_layer::InAppDirCacheLayer;
 use crate::cache::{CacheConfig, CacheError, KeepPath};
 use byte_unit::{AdjustedByte, Byte, UnitType};
-use fs_extra::dir::CopyOptions;
 use libcnb::build::BuildContext;
 use libcnb::data::layer::LayerName;
 use std::path::Path;

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -374,11 +374,9 @@ fn is_empty_dir(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use libcnb::data::layer_name;
-
     use super::*;
+    use libcnb::data::layer_name;
+    use std::str::FromStr;
 
     #[test]
     fn test_to_layer_name() {

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -148,7 +148,6 @@ impl AppCache {
         fs_err::create_dir_all(&self.cache).map_err(CacheError::IoError)?;
 
         cp_r::CopyOptions::new()
-            .create_destination(true)
             // Do not overwrite
             .filter(|to_file, _| {
                 let destination = self.path.join(to_file);
@@ -274,7 +273,6 @@ pub fn build<B: libcnb::Buildpack>(
 /// - If the copy command fails an io error will be raised.
 fn preserve_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
     cp_r::CopyOptions::new()
-        .create_destination(true)
         .copy_tree(&store.path, &store.cache)
         .map_err(|error| CacheError::CopyAppToCacheError {
             path: store.path.clone(),
@@ -296,7 +294,6 @@ fn preserve_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
 /// - If the move command fails an io error will be raised.
 fn remove_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
     cp_r::CopyOptions::new()
-        .create_destination(true)
         .copy_tree(&store.path, &store.cache)
         .map_err(|error| CacheError::DestructiveMoveAppToCacheError {
             path: store.path.clone(),

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -142,7 +142,7 @@ impl AppCache {
     /// # Errors
     ///
     /// - If files cannot be moved from the cache to the path
-    ///   then an error will be raised.
+    ///   then an io error will be raised.
     pub fn load(&self) -> Result<&Self, CacheError> {
         fs_err::create_dir_all(&self.path).map_err(CacheError::IoError)?;
         fs_err::create_dir_all(&self.cache).map_err(CacheError::IoError)?;
@@ -271,7 +271,7 @@ pub fn build<B: libcnb::Buildpack>(
 ///
 /// # Errors
 ///
-/// - If the copy command fails an `IoExtraError` will be raised.
+/// - If the copy command fails an io error will be raised.
 fn preserve_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
     cp_r::CopyOptions::new()
         .create_destination(true)
@@ -293,7 +293,7 @@ fn preserve_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
 ///
 /// # Errors
 ///
-/// - If the move command fails an `IoExtraError` will be raised.
+/// - If the move command fails an io error will be raised.
 fn remove_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
     cp_r::CopyOptions::new()
         .create_destination(true)

--- a/commons/src/cache/error.rs
+++ b/commons/src/cache/error.rs
@@ -14,7 +14,7 @@ pub enum CacheError {
     CopyCacheToAppError {
         path: PathBuf,
         cache: PathBuf,
-        error: fs_extra::error::Error,
+        error: cp_r::Error,
     },
 
     #[error("Could not copy files from the application to cache.\nFrom: {path} To: {cache}\nError: {error}")]

--- a/commons/src/cache/error.rs
+++ b/commons/src/cache/error.rs
@@ -21,14 +21,14 @@ pub enum CacheError {
     CopyAppToCacheError {
         path: PathBuf,
         cache: PathBuf,
-        error: fs_extra::error::Error,
+        error: cp_r::Error,
     },
 
     #[error("Could not move files out of the application to the cache.\nFrom: {path} To: {cache}\nError: {error}")]
     DestructiveMoveAppToCacheError {
         path: PathBuf,
         cache: PathBuf,
-        error: fs_extra::error::Error,
+        error: cp_r::Error,
     },
 
     #[error("IO error: {0}")]


### PR DESCRIPTION
Commits have more details. The short version is that I confirmed in https://github.com/heroku/buildpacks-ruby/issues/302#issuecomment-2415128173 that mtime behavior is preserved with the CNB cache. However, the fs_extra method of copying to/from the cache did not preserve mtime. The `cp_r` library is built to handle this case. 