### PR TITLE
Close #302 Copy Mtimes in the AppCache

### DIFF
--- a/commons/CHANGELOG.md
+++ b/commons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for commons features
 
+## 2024-08-16
+
+### Fixed
+
+- `AppCache` will now preserve mtime of files when copying them to/from the cache (https://github.com/heroku/buildpacks-ruby/pull/336)
+
 ## 2024-08-15
 
 ### Changed

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = "0.10"
 tempfile = "3"
 thiserror = "1"
 walkdir = "2"
+filetime = "0.2"
 
 [dev-dependencies]
 filetime = "0.2"

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -152,7 +152,7 @@ impl AppCache {
         fs_err::create_dir_all(&self.path).map_err(CacheError::IoError)?;
         fs_err::create_dir_all(&self.cache).map_err(CacheError::IoError)?;
 
-        fs_extra::dir::move_dir(
+        fs_extra::dir::copy(
             &self.cache,
             &self.path,
             &CopyOptions {
@@ -169,6 +169,8 @@ impl AppCache {
             error,
         })?;
         copy_mtime_r(&self.cache, &self.path)?;
+
+        fs_err::remove_dir_all(&self.cache).map_err(CacheError::IoError)?;
 
         Ok(self)
     }

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -306,7 +306,7 @@ fn preserve_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
 ///
 /// - If the move command fails an `IoExtraError` will be raised.
 fn remove_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
-    fs_extra::dir::move_dir(
+    fs_extra::dir::copy(
         &store.path,
         &store.cache,
         &CopyOptions {
@@ -321,6 +321,8 @@ fn remove_path_save(store: &AppCache) -> Result<&AppCache, CacheError> {
         cache: store.cache.clone(),
         error,
     })?;
+
+    fs_err::remove_dir_all(&store.path).map_err(CacheError::IoError)?;
 
     Ok(store)
 }

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -388,6 +388,31 @@ mod tests {
     }
 
     #[test]
+    fn test_load_does_not_clobber_files() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let cache_path = tmpdir.path().join("cache");
+        let app_path = tmpdir.path().join("app");
+        fs_err::create_dir_all(&cache_path).unwrap();
+        fs_err::create_dir_all(&app_path).unwrap();
+
+        fs_err::write(app_path.join("a.txt"), "app").unwrap();
+        fs_err::write(cache_path.join("a.txt"), "cache").unwrap();
+
+        let store = AppCache {
+            path: app_path.clone(),
+            cache: cache_path,
+            limit: Byte::from_u64(512),
+            keep_path: KeepPath::Runtime,
+            cache_state: CacheState::NewEmpty,
+        };
+
+        store.load().unwrap();
+
+        let contents = fs_err::read_to_string(app_path.join("a.txt")).unwrap();
+        assert_eq!("app", contents);
+    }
+
+    #[test]
     fn test_copying_back_to_cache() {
         let tmpdir = tempfile::tempdir().unwrap();
         let cache_path = tmpdir.path().join("cache");

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -388,6 +388,27 @@ mod tests {
     }
 
     #[test]
+    fn test_layer_name_cache_state() {
+        let layer_name = layer_name!("name");
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path();
+        assert_eq!(
+            CacheState::NewEmpty,
+            layer_name_cache_state(path, &layer_name)
+        );
+        fs_err::create_dir_all(path.join(layer_name.as_str())).unwrap();
+        assert_eq!(
+            CacheState::ExistsEmpty,
+            layer_name_cache_state(path, &layer_name)
+        );
+        fs_err::write(path.join(layer_name.as_str()).join("file"), "data").unwrap();
+        assert_eq!(
+            CacheState::ExistsWithContents,
+            layer_name_cache_state(path, &layer_name)
+        );
+    }
+
+    #[test]
     fn test_load_does_not_clobber_files() {
         let tmpdir = tempfile::tempdir().unwrap();
         let cache_path = tmpdir.path().join("cache");

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -302,6 +302,9 @@ fn save(store: &AppCache) -> Result<&AppCache, CacheError> {
     Ok(store)
 }
 
+/// Copies the mtime information from a path to another path
+///
+/// This is information used for the LRU cleaner so that older files are removed first.
 fn copy_mtime_r(from: &Path, to_path: &Path) -> Result<(), CacheError> {
     for entry in WalkDir::new(from).into_iter().filter_map(Result::ok) {
         let relative = entry

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -374,11 +374,9 @@ fn is_empty_dir(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use libcnb::data::layer_name;
-
     use super::*;
+    use libcnb::data::layer_name;
+    use std::str::FromStr;
 
     #[test]
     fn test_to_layer_name() {

--- a/commons/src/cache/error.rs
+++ b/commons/src/cache/error.rs
@@ -31,6 +31,13 @@ pub enum CacheError {
         error: fs_extra::error::Error,
     },
 
+    #[error("Cannot copy mtime. From: {from} To: {to_path}\nError: {error}")]
+    Mtime {
+        from: PathBuf,
+        to_path: PathBuf,
+        error: std::io::Error,
+    },
+
     #[error("IO error: {0}")]
     IoError(std::io::Error),
 


### PR DESCRIPTION
Each commit compiles and is intended to be small and readable. More information on why this option was chosen is in https://github.com/heroku/buildpacks-ruby/issues/302#issuecomment-2419661964