### PR TITLE
Change default process type host to IPv6 `::`

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Default process types defined by the Ruby buildpack now use IPv6 host `::` which is equivalent of IPv4 host `0.0.0.0`. This will only affect applications that do not define a `web` process type via the `Procfile` and [Procfile Cloud Native Buildpack](https://github.com/heroku/buildpacks-procfile). Those applications must make sure to update their configuration to bind to an IPv6 host. ([]())
+- Default process types defined by the Ruby buildpack now use IPv6 host `::` which is equivalent of IPv4 host `0.0.0.0`. This will only affect applications that do not define a `web` process type via the `Procfile` and [Procfile Cloud Native Buildpack](https://github.com/heroku/buildpacks-procfile). Those applications must make sure to update their configuration to bind to an IPv6 host. ([#354](https://github.com/heroku/buildpacks-ruby/pull/354))
 
 ### Added
 

--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default process types defined by the Ruby buildpack now use IPv6 host `::` which is equivalent of IPv4 host `0.0.0.0`. This will only affect applications that do not define a `web` process type via the `Procfile` and [Procfile Cloud Native Buildpack](https://github.com/heroku/buildpacks-procfile). Those applications must make sure to update their configuration to bind to an IPv6 host. ([]())
+
+### Added
+
 - The buildpack now warns the user when environmental variables used in running the default process are not defined. ([#307](https://github.com/heroku/buildpacks-ruby/pull/307))
 
 ## [3.0.0] - 2024-05-17

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -71,8 +71,8 @@ fn default_rack() -> Process {
             "-c",
             &[
                 "bundle exec rackup",
+                "--host \"[::]\"",
                 "--port \"${PORT:?Error: PORT env var is not set!}\"",
-                "--host \"::\"",
             ]
             .join(" "),
         ])
@@ -86,9 +86,9 @@ fn default_rails() -> Process {
             "-c",
             &[
                 "bin/rails server",
+                "--binding \"[::]\"",
                 "--port \"${PORT:?Error: PORT env var is not set!}\"",
                 "--environment \"$RAILS_ENV\"",
-                "--binding \"::\"",
             ]
             .join(" "),
         ])

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -72,7 +72,7 @@ fn default_rack() -> Process {
             &[
                 "bundle exec rackup",
                 "--port \"${PORT:?Error: PORT env var is not set!}\"",
-                "--host \"0.0.0.0\"",
+                "--host \"::\"",
             ]
             .join(" "),
         ])
@@ -88,6 +88,7 @@ fn default_rails() -> Process {
                 "bin/rails server",
                 "--port \"${PORT:?Error: PORT env var is not set!}\"",
                 "--environment \"$RAILS_ENV\"",
+                "--binding \"::\"",
             ]
             .join(" "),
         ])

--- a/buildpacks/ruby/tests/fixtures/default_ruby/Gemfile
+++ b/buildpacks/ruby/tests/fixtures/default_ruby/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem 'rack'
 gem 'rake'
-gem 'webrick'
+gem 'puma'
+gem 'rackup'

--- a/buildpacks/ruby/tests/fixtures/default_ruby/Gemfile.lock
+++ b/buildpacks/ruby/tests/fixtures/default_ruby/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (2.2.3)
-    rake (13.0.6)
-    webrick (1.7.0)
+    rack (3.1.8)
+    rake (13.2.1)
+    webrick (1.9.0)
 
 PLATFORMS
   ruby

--- a/buildpacks/ruby/tests/fixtures/default_ruby/Gemfile.lock
+++ b/buildpacks/ruby/tests/fixtures/default_ruby/Gemfile.lock
@@ -1,14 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    nio4r (2.7.4)
+    puma (6.5.0)
+      nio4r (~> 2.0)
     rack (3.1.8)
+    rackup (2.2.1)
+      rack (>= 3)
     rake (13.2.1)
-    webrick (1.9.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  puma
   rack
+  rackup
   rake
-  webrick
+
+BUNDLED WITH
+   2.5.23

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -55,7 +55,7 @@ fn test_default_app_ubuntu20() {
                 context.pack_stdout,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
 
-            assert_contains!(context.pack_stdout, "Installing webrick");
+            assert_contains!(context.pack_stdout, "Installing puma");
         },
     );
 }
@@ -72,7 +72,7 @@ fn test_default_app_ubuntu22() {
                 context.pack_stdout,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
 
-            assert_contains!(context.pack_stdout, "Installing webrick");
+            assert_contains!(context.pack_stdout, "Installing puma");
         },
     );
 }
@@ -91,7 +91,7 @@ fn test_default_app_latest_distro() {
                 context.pack_stdout,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
 
-            assert_contains!(context.pack_stdout, "Installing webrick");
+            assert_contains!(context.pack_stdout, "Installing puma");
 
             let config = context.config.clone();
             context.rebuild(config, |rebuild_context| {
@@ -107,8 +107,9 @@ fn test_default_app_latest_distro() {
                         let body = response.into_string().unwrap();
 
                         let server_logs = container.logs_now();
-                        assert_contains!(server_logs.stderr, "WEBrick::HTTPServer#start");
-                        assert_empty!(server_logs.stdout);
+
+                        assert_contains!(server_logs.stdout, "Puma starting");
+                        assert_empty!(server_logs.stderr);
 
                         assert_contains!(body, "ruby_version");
                     },

--- a/docs/application_contract.md
+++ b/docs/application_contract.md
@@ -61,9 +61,9 @@ Once an application has passed the detect phase, the build phase will execute to
         - We will delete the least recently used (LRU) files first. Detected via file mtime.
 - Process types:
   - Given an application with the `railties` gem:
-    - We will default the web process to `bin/rails server` while specifying `-p $PORT` and `-e $RAILS_ENV"`. Use the `Procfile` to override this default.
+    - We will default the web process to `bin/rails server` while specifying `--port $PORT`, `--environment $RAILS_ENV"` and an IPv6 host with `--binding "::"` (equivalent of IPv4 host `0.0.0.0`). Use the `Procfile` to override this default.
   - If `railties` gem is not found but `rack` gem is present and a `config.ru` file exists on root:
-    - We will default the web process to `rackup` while specifying `-p $PORT` and `-h 0.0.0.0`. Use the `Procfile` to override this default. .
+    - We will default the web process to `rackup` while specifying `--port $PORT` and IPv6 host with `--host "::"` (equivalent of IPv4 host `0.0.0.0`). Use the `Procfile` to override this default. .
 - Environment variable defaults - We will set a default for the following environment variables:
   - `JRUBY_OPTS="-Xcompile.invokedynamic=false"` - Invoke dynamic is a feature of the JVM intended to enhance support for dynamicaly typed languages (such as Ruby). This caused issues with Physion Passenger 4.0.16 and was disabled [details](https://github.com/heroku/heroku-buildpack-ruby/issues/145). You can override this value.
   - `RACK_ENV=${RACK_ENV:-"production"}` - An environment variable that may affect the behavior of Rack based webservers and webapps. You can override this value.


### PR DESCRIPTION
IPv6 is the future. Here's some more context heroku/roadmap#40.

Related https://github.com/heroku/ruby-getting-started/pull/165