### PR TITLE
Use `heroku/builder:24` in README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ To build a Ruby application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-ruby-app
-$ pack build sample-app --builder heroku/builder:22
+$ pack build sample-app --builder heroku/builder:24
 ```
 
 > [!NOTE]
-> You can skip needing to pass the `--builder` flag by setting a default builder with `pack config default-builder heroku/builder:22`.
+> You can skip needing to pass the `--builder` flag by setting a default builder with `pack config default-builder heroku/builder:24`.
 
 Then run the image:
 


### PR DESCRIPTION
For multi-arch support + now that Heroku-24 is the default stack instead of Heroku-22.