### PR TITLE
Fix shared layer logic

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A bug introduced in 4.0.0 would result in incorrectly skipping running `bundle install` when the `Gemfile` or `Gemfile.lock` or environment variables had changed. The bug is now fixed. ([#364](https://github.com/heroku/buildpacks-ruby/pull/364))
+
 ## [4.0.0] - 2024-11-27
 
 ### Changed


### PR DESCRIPTION
There was a bug reported where deploying a Ruby application after modifying the Gemfile.lock would result in an error because we were skipping running `bundle install`. Debugging this lead me to find that we were returning the incorrect value from our shared cache logic (accidentally returning the currnt/now value rather than the old value).

The idea behind `cached_layer_write_metadata` is to either return the old cached data or return a message stating why it couldn't be returned. It was accidentally returning the new/current value instead. This feature is used in most (nearly all) of the layers, like https://github.com/heroku/buildpacks-ruby/blob/a3f5834fb0013c6b583016c05e3b93fda62504f2/buildpacks/ruby/src/layers/bundle_install_layer.rs#L56-L62. In this logic there are some values in the metadata that trigger a cache clear https://github.com/heroku/buildpacks-ruby/blob/a3f5834fb0013c6b583016c05e3b93fda62504f2/buildpacks/ruby/src/layers/bundle_install_layer.rs#L129-L136. The rest of the values are used to persist data between runs. In this case we're looking at Gemfile and Gemfile.lock SHAs to see if they changed. The behavior fails when the current metadata object is returned rather than the old one, because that means the comparison between the value returned and the current metadata will always be identical. 

I added a unit test to assert this behavior. While developing I used an integration test to debug the issue (given below).

This commit fixes the integration test given below:

## Gemfile.lock cache invalidation integration reproduction


```term
$ cargo test test_gemfile_lock_invalidates_cache -- --exact
```

```rust
#[test]
fn test_gemfile_lock_invalidates_cache() {
    let app_dir = tempfile::tempdir().unwrap();
    fs_err::write(
        app_dir.path().join("Gemfile"),
        r#"
        source "https://rubygems.org"

        gem "rake"
    "#,
    )
    .unwrap();

    fs_err::write(
        app_dir.path().join("Gemfile.lock"),
        r"
GEM
  remote: https://rubygems.org/
  specs:
    rake (13.2.0)

PLATFORMS
  ruby

DEPENDENCIES
  rake
",
    )
    .unwrap();
    let mut config = amd_arm_builder_config("heroku/builder:24", &app_dir.path().to_string_lossy());
    TestRunner::default().build(
        config.clone()
        .buildpacks([
            BuildpackReference::CurrentCrate,
        ]),
        |context| {
            let stdout = context.pack_stdout.clone();
            println!("{}", stdout);
            assert_contains!(stdout, "# Heroku Ruby Buildpack");
            assert_contains!(
                stdout,
                r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#
            );
            assert_contains!(stdout, "Installing rake");

    fs_err::write(
        app_dir.path().join("Gemfile.lock"),
        r"
GEM
  remote: https://rubygems.org/
  specs:
    rake (13.2.1)

PLATFORMS
  ruby

DEPENDENCIES
  rake
",
    )
    .unwrap();

            context.rebuild(
                config.buildpacks([BuildpackReference::CurrentCrate]),
                |rebuild_context| {
                    println!("{}", rebuild_context.pack_stdout);

                assert_contains!(
                    rebuild_context.pack_stdout,
                    r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#
                );
                assert_contains!(rebuild_context.pack_stdout, "Installing rake");
                },
            );
        });
}
```