### PR TITLE
The last commit here fails to compile pushing it here to reference from an issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
+name = "cache_diff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2afc054cd5e2f8a0fb0122db671c3731849b1fcc86ec664e1031834a0828b84b"
+dependencies = [
+ "bullet_stream",
+ "cache_diff_derive",
+]
+
+[[package]]
+name = "cache_diff_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273bbd860603cb240372b460f8dc2440528ba95593f944b549194eb8600285a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +593,7 @@ name = "heroku-ruby-buildpack"
 version = "0.0.0"
 dependencies = [
  "bullet_stream",
+ "cache_diff",
  "clap",
  "commons",
  "flate2",
@@ -1308,6 +1331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1453,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["buildpacks/ruby", "commons"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.82"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/ruby/Cargo.toml
+++ b/buildpacks/ruby/Cargo.toml
@@ -30,6 +30,7 @@ ureq = { version = "2", default-features = false, features = ["tls"] }
 url = "2"
 magic_migrate = "0.2"
 toml = "0.8"
+cache_diff = { version = "1.0.0", features = ["bullet_stream"] }
 
 [dev-dependencies]
 libcnb-test = "=0.26.1"

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -60,15 +60,7 @@ try_migrate_deserializer_chain!(
 
 impl MetadataDiff for Metadata {
     fn diff(&self, other: &Self) -> Vec<String> {
-        let mut differences = Vec::new();
-        if self.version != other.version {
-            differences.push(format!(
-                "Bundler version ({old} to {now})",
-                old = style::value(other.version.to_string()),
-                now = style::value(self.version.to_string())
-            ));
-        }
-        differences
+        <Self as CacheDiff>::diff(self, other)
     }
 }
 
@@ -143,12 +135,14 @@ mod test {
         let old = Metadata {
             version: ResolvedBundlerVersion("2.3.5".to_string()),
         };
-        assert!(old.diff(&old).is_empty());
+        assert!(CacheDiff::diff(&old, &old).is_empty());
 
-        let diff = Metadata {
-            version: ResolvedBundlerVersion("2.3.6".to_string()),
-        }
-        .diff(&old);
+        let diff = CacheDiff::diff(
+            &Metadata {
+                version: ResolvedBundlerVersion("2.3.6".to_string()),
+            },
+            &old,
+        );
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Bundler version (`2.3.5` to `2.3.6`)"]

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -9,6 +9,7 @@ use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
 use bullet_stream::state::SubBullet;
 use bullet_stream::{style, Print};
+use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedBundlerVersion;
 use fun_run::{self, CommandWithName};
 use libcnb::data::layer_name;
@@ -71,8 +72,9 @@ impl MetadataDiff for Metadata {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, CacheDiff)]
 pub(crate) struct MetadataV1 {
+    #[cache_diff(rename = "Bundler version")]
     pub(crate) version: ResolvedBundlerVersion,
 }
 


### PR DESCRIPTION
This code fails to compile with an error

```
error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> buildpacks/ruby/src/layers/bundle_install_layer.rs:120:1
    |
120 | / try_migrate_deserializer_chain!(
121 | |     chain: [MetadataV1, MetadataV2, MetadataV3],
122 | |     error: MetadataMigrateError,
123 | |     deserializer: toml::Deserializer::new,
124 | | );
    | |_^
    |
    = note: this error originates in the macro `$crate::try_migrate_link` which comes from the expansion of the macro `try_migrate_deserializer_chain` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Or with nightly:

```
$ RUSTFLAGS="-Zmacro-backtrace" cargo build
error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> /Users/rschneeman/.cargo/registry/src/index.crates.io-6f17d22bba15001f/magic_migrate-0.2.0/src/lib.rs:437:34
    |
419 |   macro_rules! try_migrate_link {
    |   ----------------------------- in this expansion of `$crate::try_migrate_link!` (#3)
...
437 |           $crate::try_migrate_link!($b, $($rest),*)
    |                                    ^^^^^^^^^^^^^^^^
...
714 |   macro_rules! try_migrate_deserializer_chain {
    |   -------------------------------------------
    |   |
    |   in this expansion of `try_migrate_deserializer_chain!` (#1)
    |   in this expansion of `$crate::try_migrate_deserializer_chain!` (#2)
...
737 |           $crate::try_migrate_link!($a, $($rest),+);
    |           ----------------------------------------- in this macro invocation (#3)
...
764 |           $crate::try_migrate_deserializer_chain!(error: $err, deserializer: $deser, chain: [$a, $($rest),+]);
    |           --------------------------------------------------------------------------------------------------- in this macro invocation (#2)
    |
   ::: buildpacks/ruby/src/layers/bundle_install_layer.rs:120:1
    |
120 | / try_migrate_deserializer_chain!(
121 | |     chain: [MetadataV1, MetadataV2, MetadataV3],
122 | |     error: MetadataMigrateError,
123 | |     deserializer: toml::Deserializer::new,
124 | | );
    | |_- in this macro invocation (#1)

error: could not compile `heroku-ruby-buildpack` (bin "heroku-ruby-buildpack") due to 1 previous error
```

I'm committing it because I want to figure out how to write a test case for this failure mode in the `magic_migrate` library.
