### PR TITLE
Adopt CacheDiff (crate) over MetadataDiff (internal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
+name = "cache_diff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2afc054cd5e2f8a0fb0122db671c3731849b1fcc86ec664e1031834a0828b84b"
+dependencies = [
+ "bullet_stream",
+ "cache_diff_derive",
+]
+
+[[package]]
+name = "cache_diff_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273bbd860603cb240372b460f8dc2440528ba95593f944b549194eb8600285a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +593,7 @@ name = "heroku-ruby-buildpack"
 version = "0.0.0"
 dependencies = [
  "bullet_stream",
+ "cache_diff",
  "clap",
  "commons",
  "flate2",
@@ -1308,6 +1331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1453,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,9 +968,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "magic_migrate"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c05b570dc24563cf1720263bbeeb78822c8d3ce75debe510ca6bae90dd0cccf"
+checksum = "3995455690a60dcbb8688d0f0e84eee5322eb1cdd5e9a9bf0ac7b2aa56250291"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["buildpacks/ruby", "commons"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.82"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/ruby/Cargo.toml
+++ b/buildpacks/ruby/Cargo.toml
@@ -30,6 +30,7 @@ ureq = { version = "2", default-features = false, features = ["tls"] }
 url = "2"
 magic_migrate = "0.2"
 toml = "0.8"
+cache_diff = { version = "1.0.0", features = ["bullet_stream"] }
 
 [dev-dependencies]
 libcnb-test = "=0.26.1"

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -129,14 +129,12 @@ mod test {
         let old = Metadata {
             version: ResolvedBundlerVersion("2.3.5".to_string()),
         };
-        assert!(CacheDiff::diff(&old, &old).is_empty());
+        assert!(old.diff(&old).is_empty());
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                version: ResolvedBundlerVersion("2.3.6".to_string()),
-            },
-            &old,
-        );
+        let diff = Metadata {
+            version: ResolvedBundlerVersion("2.3.6".to_string()),
+        }
+        .diff(&old);
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Bundler version (`2.3.5` to `2.3.6`)"]

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -60,15 +60,7 @@ try_migrate_deserializer_chain!(
 
 impl MetadataDiff for Metadata {
     fn diff(&self, other: &Self) -> Vec<String> {
-        let mut differences = Vec::new();
-        if self.version != other.version {
-            differences.push(format!(
-                "Bundler version ({old} to {now})",
-                old = style::value(other.version.to_string()),
-                now = style::value(self.version.to_string())
-            ));
-        }
-        differences
+        <Self as CacheDiff>::diff(self, other)
     }
 }
 
@@ -143,12 +135,14 @@ mod test {
         let old = Metadata {
             version: ResolvedBundlerVersion("2.3.5".to_string()),
         };
-        assert!(old.diff(&old).is_empty());
+        assert!(CacheDiff::diff(&old, &old).is_empty());
 
-        let diff = Metadata {
-            version: ResolvedBundlerVersion("2.3.6".to_string()),
-        }
-        .diff(&old);
+        let diff = CacheDiff::diff(
+            &Metadata {
+                version: ResolvedBundlerVersion("2.3.6".to_string()),
+            },
+            &old,
+        );
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Bundler version (`2.3.5` to `2.3.6`)"]

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -4,7 +4,7 @@
 //!
 //! Installs a copy of `bundler` to the `<layer-dir>` with a bundler executable in
 //! `<layer-dir>/bin`. Must run before [`crate.steps.bundle_install`].
-use crate::layers::shared::{cached_layer_write_metadata, MetadataDiff};
+use crate::layers::shared::cached_layer_write_metadata;
 use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
 use bullet_stream::state::SubBullet;
@@ -57,12 +57,6 @@ try_migrate_deserializer_chain!(
     error: MetadataError,
     chain: [MetadataV1],
 );
-
-impl MetadataDiff for Metadata {
-    fn diff(&self, other: &Self) -> Vec<String> {
-        <Self as CacheDiff>::diff(self, other)
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug, Clone, CacheDiff)]
 pub(crate) struct MetadataV1 {

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -9,6 +9,7 @@ use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
 use bullet_stream::state::SubBullet;
 use bullet_stream::{style, Print};
+use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedBundlerVersion;
 use fun_run::{self, CommandWithName};
 use libcnb::data::layer_name;
@@ -71,8 +72,9 @@ impl MetadataDiff for Metadata {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, CacheDiff)]
 pub(crate) struct MetadataV1 {
+    #[cache_diff(rename = "Bundler version")]
     pub(crate) version: ResolvedBundlerVersion,
 }
 

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -356,46 +356,52 @@ mod test {
             )
             .unwrap(),
         };
-        assert_eq!(old.diff(&old), Vec::<String>::new());
+        assert_eq!(CacheDiff::diff(&old, &old), Vec::<String>::new());
 
-        let diff = Metadata {
-            ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
-            os_distribution: old.os_distribution.clone(),
-            cpu_architecture: old.cpu_architecture.clone(),
-            force_bundle_install_key: old.force_bundle_install_key.clone(),
-            digest: old.digest.clone(),
-        }
-        .diff(&old);
+        let diff = CacheDiff::diff(
+            &Metadata {
+                ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
+                os_distribution: old.os_distribution.clone(),
+                cpu_architecture: old.cpu_architecture.clone(),
+                force_bundle_install_key: old.force_bundle_install_key.clone(),
+                digest: old.digest.clone(),
+            },
+            &old,
+        );
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Ruby version (`3.5.3` to `3.5.5`)".to_string()]
         );
 
-        let diff = Metadata {
-            ruby_version: old.ruby_version.clone(),
-            os_distribution: "alpine 3.20.0".to_string(),
-            cpu_architecture: old.cpu_architecture.clone(),
-            force_bundle_install_key: old.force_bundle_install_key.clone(),
-            digest: old.digest.clone(),
-        }
-        .diff(&old);
-
-        assert_eq!(
-            diff.iter().map(strip_ansi).collect::<Vec<String>>(),
-            vec!["Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
+        let diff = CacheDiff::diff(
+            &Metadata {
+                ruby_version: old.ruby_version.clone(),
+                os_distribution: "alpine 3.20.0".to_string(),
+                cpu_architecture: old.cpu_architecture.clone(),
+                force_bundle_install_key: old.force_bundle_install_key.clone(),
+                digest: old.digest.clone(),
+            },
+            &old,
         );
 
-        let diff = Metadata {
-            ruby_version: old.ruby_version.clone(),
-            os_distribution: old.os_distribution.clone(),
-            cpu_architecture: "arm64".to_string(),
-            force_bundle_install_key: old.force_bundle_install_key.clone(),
-            digest: old.digest.clone(),
-        }
-        .diff(&old);
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
-            vec!["CPU architecture (`amd64` to `arm64`)".to_string()]
+            vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
+        );
+
+        let diff = CacheDiff::diff(
+            &Metadata {
+                ruby_version: old.ruby_version.clone(),
+                os_distribution: old.os_distribution.clone(),
+                cpu_architecture: "arm64".to_string(),
+                force_bundle_install_key: old.force_bundle_install_key.clone(),
+                digest: old.digest.clone(),
+            },
+            &old,
+        );
+        assert_eq!(
+            diff.iter().map(strip_ansi).collect::<Vec<String>>(),
+            vec!["CPU Architecture (`amd64` to `arm64`)".to_string()]
         );
     }
 

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -356,52 +356,48 @@ mod test {
             )
             .unwrap(),
         };
-        assert_eq!(CacheDiff::diff(&old, &old), Vec::<String>::new());
+        assert_eq!(old.diff(&old), Vec::<String>::new());
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
-                os_distribution: old.os_distribution.clone(),
-                cpu_architecture: old.cpu_architecture.clone(),
-                force_bundle_install_key: old.force_bundle_install_key.clone(),
-                digest: old.digest.clone(),
-            },
-            &old,
-        );
+        let diff = Metadata {
+            ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
+            os_distribution: old.os_distribution.clone(),
+            cpu_architecture: old.cpu_architecture.clone(),
+            force_bundle_install_key: old.force_bundle_install_key.clone(),
+            digest: old.digest.clone(),
+        }
+        .diff(&old);
+
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Ruby version (`3.5.3` to `3.5.5`)".to_string()]
         );
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                ruby_version: old.ruby_version.clone(),
-                os_distribution: OsDistribution {
-                    name: "alpine".to_string(),
-                    version: "3.20.0".to_string(),
-                },
-                cpu_architecture: old.cpu_architecture.clone(),
-                force_bundle_install_key: old.force_bundle_install_key.clone(),
-                digest: old.digest.clone(),
+        let diff = Metadata {
+            ruby_version: old.ruby_version.clone(),
+            os_distribution: OsDistribution {
+                name: "alpine".to_string(),
+                version: "3.20.0".to_string(),
             },
-            &old,
-        );
+            cpu_architecture: old.cpu_architecture.clone(),
+            force_bundle_install_key: old.force_bundle_install_key.clone(),
+            digest: old.digest.clone(),
+        }
+        .diff(&old);
 
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
         );
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                ruby_version: old.ruby_version.clone(),
-                os_distribution: old.os_distribution.clone(),
-                cpu_architecture: "arm64".to_string(),
-                force_bundle_install_key: old.force_bundle_install_key.clone(),
-                digest: old.digest.clone(),
-            },
-            &old,
-        );
+        let diff = Metadata {
+            ruby_version: old.ruby_version.clone(),
+            os_distribution: old.os_distribution.clone(),
+            cpu_architecture: "arm64".to_string(),
+            force_bundle_install_key: old.force_bundle_install_key.clone(),
+            digest: old.digest.clone(),
+        }
+        .diff(&old);
+
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["CPU Architecture (`amd64` to `arm64`)".to_string()]

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -14,7 +14,7 @@
 //! must be compiled and will then be invoked via FFI. These native extensions are
 //! OS, Architecture, and Ruby version dependent. Due to this, when one of these changes
 //! we must clear the cache and re-run `bundle install`.
-use crate::layers::shared::{cached_layer_write_metadata, Meta, MetadataDiff};
+use crate::layers::shared::{cached_layer_write_metadata, Meta};
 use crate::target_id::{OsDistribution, TargetId, TargetIdError};
 use crate::{BundleWithout, RubyBuildpack, RubyBuildpackError};
 use bullet_stream::state::SubBullet;
@@ -123,12 +123,6 @@ try_migrate_deserializer_chain!(
     error: MetadataMigrateError,
     deserializer: toml::Deserializer::new,
 );
-
-impl MetadataDiff for Metadata {
-    fn diff(&self, old: &Self) -> Vec<String> {
-        <Self as CacheDiff>::diff(self, old)
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct MetadataV1 {
@@ -334,7 +328,7 @@ mod test {
     use super::*;
     use std::path::PathBuf;
 
-    /// `MetadataDiff` logic controls cache invalidation
+    /// `CacheDiff` logic controls cache invalidation
     /// When the vec is empty the cache is kept, otherwise it is invalidated
     #[test]
     fn metadata_diff_messages() {

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -322,52 +322,48 @@ version = "3.1.3"
             },
             cpu_architecture: "amd64".to_string(),
         };
-        assert_eq!(CacheDiff::diff(&old, &old), Vec::<String>::new());
+        assert_eq!(old.diff(&old), Vec::<String>::new());
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
-                os_distribution: OsDistribution {
-                    name: "ubuntu".to_string(),
-                    version: "20.04".to_string(),
-                },
-                cpu_architecture: old.cpu_architecture.clone(),
+        let diff = Metadata {
+            ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
+            os_distribution: OsDistribution {
+                name: "ubuntu".to_string(),
+                version: "20.04".to_string(),
             },
-            &old,
-        );
+            cpu_architecture: old.cpu_architecture.clone(),
+        }
+        .diff(&old);
+
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Ruby version (`3.5.3` to `3.5.5`)".to_string()]
         );
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                ruby_version: old.ruby_version.clone(),
-                os_distribution: OsDistribution {
-                    name: "alpine".to_string(),
-                    version: "3.20.0".to_string(),
-                },
-                cpu_architecture: old.cpu_architecture.clone(),
+        let diff = Metadata {
+            ruby_version: old.ruby_version.clone(),
+            os_distribution: OsDistribution {
+                name: "alpine".to_string(),
+                version: "3.20.0".to_string(),
             },
-            &old,
-        );
+            cpu_architecture: old.cpu_architecture.clone(),
+        }
+        .diff(&old);
 
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
         );
 
-        let diff = CacheDiff::diff(
-            &Metadata {
-                ruby_version: old.ruby_version.clone(),
-                os_distribution: OsDistribution {
-                    name: old.os_distribution.name.clone(),
-                    version: old.os_distribution.version.clone(),
-                },
-                cpu_architecture: "arm64".to_string(),
+        let diff = Metadata {
+            ruby_version: old.ruby_version.clone(),
+            os_distribution: OsDistribution {
+                name: old.os_distribution.name.clone(),
+                version: old.os_distribution.version.clone(),
             },
-            &old,
-        );
+            cpu_architecture: "arm64".to_string(),
+        }
+        .diff(&old);
+
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["CPU architecture (`amd64` to `arm64`)".to_string()]
@@ -386,7 +382,7 @@ version = "3.1.3"
             },
             cpu_architecture: "x86_64".to_string(),
         };
-        let differences = CacheDiff::diff(&old, &old);
+        let differences = old.diff(&old);
         assert_eq!(differences, Vec::<String>::new());
 
         cached_layer_write_metadata(layer_name!("ruby"), &context, &old).unwrap();
@@ -398,7 +394,7 @@ version = "3.1.3"
             ruby_version: ResolvedRubyVersion("3.0.0".to_string()),
             ..old.clone()
         };
-        let differences = CacheDiff::diff(&now, &old);
+        let differences = now.diff(&old);
         assert_eq!(differences.len(), 1);
 
         let result = cached_layer_write_metadata(layer_name!("ruby"), &context, &now).unwrap();

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -18,7 +18,7 @@ use crate::{
     RubyBuildpack, RubyBuildpackError,
 };
 use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::Print;
 use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedRubyVersion;
 use flate2::read::GzDecoder;
@@ -328,46 +328,52 @@ version = "3.1.3"
             },
             cpu_architecture: "amd64".to_string(),
         };
-        assert_eq!(old.diff(&old), Vec::<String>::new());
+        assert_eq!(CacheDiff::diff(&old, &old), Vec::<String>::new());
 
-        let diff = Metadata {
-            ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
-            os_distribution: OsDistribution {
-                name: "ubuntu".to_string(),
-                version: "20.04".to_string(),
+        let diff = CacheDiff::diff(
+            &Metadata {
+                ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
+                os_distribution: OsDistribution {
+                    name: "ubuntu".to_string(),
+                    version: "20.04".to_string(),
+                },
+                cpu_architecture: old.cpu_architecture.clone(),
             },
-            cpu_architecture: old.cpu_architecture.clone(),
-        }
-        .diff(&old);
+            &old,
+        );
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["Ruby version (`3.5.3` to `3.5.5`)".to_string()]
         );
 
-        let diff = Metadata {
-            ruby_version: old.ruby_version.clone(),
-            os_distribution: OsDistribution {
-                name: "alpine".to_string(),
-                version: "3.20.0".to_string(),
+        let diff = CacheDiff::diff(
+            &Metadata {
+                ruby_version: old.ruby_version.clone(),
+                os_distribution: OsDistribution {
+                    name: "alpine".to_string(),
+                    version: "3.20.0".to_string(),
+                },
+                cpu_architecture: old.cpu_architecture.clone(),
             },
-            cpu_architecture: old.cpu_architecture.clone(),
-        }
-        .diff(&old);
+            &old,
+        );
 
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
         );
 
-        let diff = Metadata {
-            ruby_version: old.ruby_version.clone(),
-            os_distribution: OsDistribution {
-                name: old.os_distribution.name.clone(),
-                version: old.os_distribution.version.clone(),
+        let diff = CacheDiff::diff(
+            &Metadata {
+                ruby_version: old.ruby_version.clone(),
+                os_distribution: OsDistribution {
+                    name: old.os_distribution.name.clone(),
+                    version: old.os_distribution.version.clone(),
+                },
+                cpu_architecture: "arm64".to_string(),
             },
-            cpu_architecture: "arm64".to_string(),
-        }
-        .diff(&old);
+            &old,
+        );
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
             vec!["CPU architecture (`amd64` to `arm64`)".to_string()]
@@ -386,7 +392,7 @@ version = "3.1.3"
             },
             cpu_architecture: "x86_64".to_string(),
         };
-        let differences = old.diff(&old);
+        let differences = CacheDiff::diff(&old, &old);
         assert_eq!(differences, Vec::<String>::new());
 
         cached_layer_write_metadata(layer_name!("ruby"), &context, &old).unwrap();
@@ -398,7 +404,7 @@ version = "3.1.3"
             ruby_version: ResolvedRubyVersion("3.0.0".to_string()),
             ..old.clone()
         };
-        let differences = now.diff(&old);
+        let differences = CacheDiff::diff(&now, &old);
         assert_eq!(differences.len(), 1);
 
         let result = cached_layer_write_metadata(layer_name!("ruby"), &context, &now).unwrap();

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -275,18 +275,22 @@ mod tests {
     #[test]
     fn metadata_guard() {
         let metadata = Metadata {
-            distro_name: String::from("ubuntu"),
-            distro_version: String::from("22.04"),
+            os_distribution: OsDistribution {
+                name: String::from("ubuntu"),
+                version: String::from("22.04"),
+            },
             cpu_architecture: String::from("amd64"),
             ruby_version: ResolvedRubyVersion(String::from("3.1.3")),
         };
 
         let actual = toml::to_string(&metadata).unwrap();
         let expected = r#"
-distro_name = "ubuntu"
-distro_version = "22.04"
 cpu_architecture = "amd64"
 ruby_version = "3.1.3"
+
+[os_distribution]
+name = "ubuntu"
+version = "22.04"
 "#
         .trim();
         assert_eq!(expected, actual.trim());
@@ -342,16 +346,20 @@ version = "3.1.3"
     fn metadata_diff_messages() {
         let old = Metadata {
             ruby_version: ResolvedRubyVersion("3.5.3".to_string()),
-            distro_name: "ubuntu".to_string(),
-            distro_version: "20.04".to_string(),
+            os_distribution: OsDistribution {
+                name: "ubuntu".to_string(),
+                version: "20.04".to_string(),
+            },
             cpu_architecture: "amd64".to_string(),
         };
         assert_eq!(old.diff(&old), Vec::<String>::new());
 
         let diff = Metadata {
             ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
-            distro_name: old.distro_name.clone(),
-            distro_version: old.distro_version.clone(),
+            os_distribution: OsDistribution {
+                name: "ubuntu".to_string(),
+                version: "20.04".to_string(),
+            },
             cpu_architecture: old.cpu_architecture.clone(),
         }
         .diff(&old);
@@ -362,21 +370,25 @@ version = "3.1.3"
 
         let diff = Metadata {
             ruby_version: old.ruby_version.clone(),
-            distro_name: "alpine".to_string(),
-            distro_version: "3.20.0".to_string(),
+            os_distribution: OsDistribution {
+                name: "alpine".to_string(),
+                version: "3.20.0".to_string(),
+            },
             cpu_architecture: old.cpu_architecture.clone(),
         }
         .diff(&old);
 
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
-            vec!["Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
+            vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
         );
 
         let diff = Metadata {
             ruby_version: old.ruby_version.clone(),
-            distro_name: old.distro_name.clone(),
-            distro_version: old.distro_version.clone(),
+            os_distribution: OsDistribution {
+                name: old.os_distribution.name.clone(),
+                version: old.os_distribution.version.clone(),
+            },
             cpu_architecture: "arm64".to_string(),
         }
         .diff(&old);
@@ -392,8 +404,10 @@ version = "3.1.3"
         let context = temp_build_context::<RubyBuildpack>(temp.path());
         let old = Metadata {
             ruby_version: ResolvedRubyVersion("2.7.2".to_string()),
-            distro_name: "ubuntu".to_string(),
-            distro_version: "20.04".to_string(),
+            os_distribution: OsDistribution {
+                name: "ubuntu".to_string(),
+                version: "20.04".to_string(),
+            },
             cpu_architecture: "x86_64".to_string(),
         };
         let differences = old.diff(&old);

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -11,7 +11,7 @@
 //!
 //! When the Ruby version changes, invalidate and re-run.
 //!
-use crate::layers::shared::{cached_layer_write_metadata, MetadataDiff};
+use crate::layers::shared::cached_layer_write_metadata;
 use crate::target_id::OsDistribution;
 use crate::{
     target_id::{TargetId, TargetIdError},
@@ -150,12 +150,6 @@ impl TryFrom<MetadataV2> for MetadataV3 {
             cpu_architecture: v2.cpu_architecture,
             ruby_version: v2.ruby_version,
         })
-    }
-}
-
-impl MetadataDiff for Metadata {
-    fn diff(&self, old: &Self) -> Vec<String> {
-        <Self as CacheDiff>::diff(self, old)
     }
 }
 

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 /// Default behavior for a cached layer, ensures new metadata is always written
 ///
-/// The metadadata must implement `MetadataDiff` and `TryMigrate` in addition
+/// The metadadata must implement `CacheDiff` and `TryMigrate` in addition
 /// to the typical `Serialize` and `Debug` traits
 pub(crate) fn cached_layer_write_metadata<M, B>(
     layer_name: LayerName,
@@ -32,13 +32,6 @@ where
     )?;
     layer_ref.write_metadata(metadata)?;
     Ok(layer_ref)
-}
-
-/// Given another metadata object, returns a list of differences between the two
-///
-/// If no differences, return an empty list
-pub(crate) trait MetadataDiff {
-    fn diff(&self, old: &Self) -> Vec<String>;
 }
 
 /// Standardizes formatting for layer cache clearing behavior
@@ -225,11 +218,6 @@ mod tests {
             }
         }
     }
-    impl MetadataDiff for TestMetadata {
-        fn diff(&self, old: &Self) -> Vec<String> {
-            <Self as CacheDiff>::diff(self, old)
-        }
-    }
     migrate_toml_chain! {TestMetadata}
 
     #[test]
@@ -238,15 +226,9 @@ mod tests {
         struct AlwaysNoDiff {
             value: String,
         }
-
         impl CacheDiff for AlwaysNoDiff {
             fn diff(&self, _: &Self) -> Vec<String> {
                 vec![]
-            }
-        }
-        impl MetadataDiff for AlwaysNoDiff {
-            fn diff(&self, _: &Self) -> Vec<String> {
-                <Self as CacheDiff>::diff(self, self)
             }
         }
 

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -14,7 +14,7 @@ pub(crate) fn cached_layer_write_metadata<M, B>(
 ) -> libcnb::Result<LayerRef<B, Meta<M>, Meta<M>>, B::Error>
 where
     B: libcnb::Buildpack,
-    M: MetadataDiff + magic_migrate::TryMigrate + serde::ser::Serialize + std::fmt::Debug + Clone,
+    M: CacheDiff + magic_migrate::TryMigrate + serde::ser::Serialize + std::fmt::Debug + Clone,
     <M as magic_migrate::TryMigrate>::Error: std::fmt::Display,
 {
     let layer_ref = context.cached_layer(
@@ -43,7 +43,7 @@ pub(crate) trait MetadataDiff {
 /// If the diff is not empty, the layer is deleted and the changes are listed
 pub(crate) fn restored_layer_action<M>(old: &M, now: &M) -> (RestoredLayerAction, Meta<M>)
 where
-    M: MetadataDiff + Clone,
+    M: CacheDiff + Clone,
 {
     let diff = now.diff(old);
     if diff.is_empty() {

--- a/buildpacks/ruby/src/layers/shared.rs
+++ b/buildpacks/ruby/src/layers/shared.rs
@@ -1,3 +1,4 @@
+use cache_diff::CacheDiff;
 use commons::display::SentenceList;
 use libcnb::build::BuildContext;
 use libcnb::layer::{CachedLayerDefinition, InvalidMetadataAction, LayerRef, RestoredLayerAction};
@@ -211,13 +212,18 @@ mod tests {
     struct TestMetadata {
         value: String,
     }
-    impl MetadataDiff for TestMetadata {
+    impl CacheDiff for TestMetadata {
         fn diff(&self, old: &Self) -> Vec<String> {
             if self.value == old.value {
                 vec![]
             } else {
                 vec![format!("value ({} to {})", old.value, self.value)]
             }
+        }
+    }
+    impl MetadataDiff for TestMetadata {
+        fn diff(&self, old: &Self) -> Vec<String> {
+            <Self as CacheDiff>::diff(self, old)
         }
     }
     migrate_toml_chain! {TestMetadata}
@@ -229,9 +235,14 @@ mod tests {
             value: String,
         }
 
-        impl MetadataDiff for AlwaysNoDiff {
+        impl CacheDiff for AlwaysNoDiff {
             fn diff(&self, _: &Self) -> Vec<String> {
                 vec![]
+            }
+        }
+        impl MetadataDiff for AlwaysNoDiff {
+            fn diff(&self, _: &Self) -> Vec<String> {
+                <Self as CacheDiff>::diff(self, self)
             }
         }
 

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -151,8 +151,10 @@ impl Buildpack for RubyBuildpack {
                 &context,
                 bullet,
                 &layers::ruby_install_layer::Metadata {
-                    distro_name: context.target.distro_name.clone(),
-                    distro_version: context.target.distro_version.clone(),
+                    os_distribution: OsDistribution {
+                        name: context.target.distro_name.clone(),
+                        version: context.target.distro_version.clone(),
+                    },
                     cpu_architecture: context.target.arch.clone(),
                     ruby_version: ruby_version.clone(),
                 },

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -31,6 +31,8 @@ use libcnb_test as _;
 
 use clap as _;
 
+use crate::target_id::OsDistribution;
+
 struct RubyBuildpack;
 
 #[derive(Debug, thiserror::Error)]
@@ -186,10 +188,10 @@ impl Buildpack for RubyBuildpack {
                 &env,
                 bullet,
                 &layers::bundle_install_layer::Metadata {
-                    os_distribution: format!(
-                        "{} {}",
-                        context.target.distro_name, context.target.distro_version
-                    ),
+                    os_distribution: OsDistribution {
+                        name: context.target.distro_name.clone(),
+                        version: context.target.distro_version.clone(),
+                    },
                     cpu_architecture: context.target.arch.clone(),
                     ruby_version: ruby_version.clone(),
                     force_bundle_install_key: String::from(

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -186,8 +186,10 @@ impl Buildpack for RubyBuildpack {
                 &env,
                 bullet,
                 &layers::bundle_install_layer::Metadata {
-                    distro_name: context.target.distro_name.clone(),
-                    distro_version: context.target.distro_version.clone(),
+                    os_distribution: format!(
+                        "{} {}",
+                        context.target.distro_name, context.target.distro_version
+                    ),
                     cpu_architecture: context.target.arch.clone(),
                     ruby_version: ruby_version.clone(),
                     force_bundle_install_key: String::from(

--- a/buildpacks/ruby/src/target_id.rs
+++ b/buildpacks/ruby/src/target_id.rs
@@ -1,6 +1,5 @@
-use std::fmt::{Display, Formatter};
-
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TargetId {

--- a/buildpacks/ruby/src/target_id.rs
+++ b/buildpacks/ruby/src/target_id.rs
@@ -1,3 +1,7 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TargetId {
     pub(crate) distro_name: String,
@@ -48,6 +52,18 @@ impl TargetId {
                 distro_version: version.to_owned(),
             })
             .ok_or_else(|| TargetIdError::UnknownStack(stack_id.to_owned()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub(crate) struct OsDistribution {
+    pub(crate) name: String,
+    pub(crate) version: String,
+}
+
+impl Display for OsDistribution {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.name, self.version)
     }
 }
 

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -19,14 +19,15 @@ fn test_migrating_metadata() {
     // This test is a placeholder for when a change modifies metadata structures.
     // Remove the return and update the `buildpack-ruby` reference to the latest version.
     #![allow(unreachable_code)]
-    return;
+    // Test v4.0.2 compatible with v4.0.1
+    // return;
 
-    let builder = "heroku/builder:22";
+    let builder = "heroku/builder:24";
     let app_dir = "tests/fixtures/default_ruby";
 
     TestRunner::default().build(
         BuildConfig::new(builder, app_dir).buildpacks([BuildpackReference::Other(
-            "docker://docker.io/heroku/buildpack-ruby:2.1.2".to_string(),
+            "docker://docker.io/heroku/buildpack-ruby:4.0.1".to_string(),
         )]),
         |context| {
             println!("{}", context.pack_stdout);

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -4,8 +4,8 @@
 #![allow(clippy::unwrap_used)]
 
 use libcnb_test::{
-    assert_contains, assert_empty, BuildConfig, BuildpackReference, ContainerConfig,
-    ContainerContext, TestRunner,
+    assert_contains, assert_contains_match, assert_empty, BuildConfig, BuildpackReference,
+    ContainerConfig, ContainerContext, TestRunner,
 };
 use std::thread;
 use std::time::{Duration, Instant};
@@ -36,8 +36,18 @@ fn test_migrating_metadata() {
                 |rebuild_context| {
                     println!("{}", rebuild_context.pack_stdout);
 
-                    assert_contains!(rebuild_context.pack_stdout, "Using cached Ruby version");
-                    assert_contains!(rebuild_context.pack_stdout, "Loading cached gems");
+                    assert_contains_match!(
+                        rebuild_context.pack_stdout,
+                        r"^- Ruby version[^\n]*\n  - Using cache"
+                    );
+                    assert_contains_match!(
+                        rebuild_context.pack_stdout,
+                        r"^- Bundler version[^\n]*\n  - Using cache"
+                    );
+                    assert_contains_match!(
+                        rebuild_context.pack_stdout,
+                        r"^- Bundle install gems[^\n]*\n  - Using cache"
+                    );
                 },
             );
         },


### PR DESCRIPTION
The `MetadataDiff` was a prototype for how to extract cache clearing logic to a centralized trait. From there I changed the name and built a proc-macro that can generate the same logic https://github.com/heroku-buildpacks/cache_diff. The benefit of the proc macro is it works with defaults out of the box and adds consistency. 

This PR moves the old code using MetadataDiff to now use `CacheDiff`. In the process I refactored some logic, namely how the OS distribution information is stored as metadata. Commits are small, sequential and self described.