### PR TITLE
Add missing deny unknown fields

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Layer metadata deserialization to Rust structs is now using `#[serde(deny_unknown_fields)]` this prevents the accidental scenario where metadata containing a superset of fields could accidentally be deserialized to the wrong struct. It's unlikely this is currently happening with the current buildpack, but it's a possibly-observable difference so it's being listed ([#371](https://github.com/heroku/buildpacks-ruby/pull/371))
+
 ## [4.0.1] - 2024-12-11
 
 ### Fixed

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -145,6 +145,7 @@ pub(crate) struct MetadataV2 {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, CacheDiff)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct MetadataV3 {
     #[cache_diff(rename = "OS Distribution")]
     pub(crate) os_distribution: OsDistribution,

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -316,14 +316,6 @@ fn display_name(cmd: &mut Command, env: &Env) -> String {
     )
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct BundleDigest {
-    env: String,
-    gemfile: String,
-    lockfile: String,
-}
-
 #[cfg(test)]
 mod test {
     use crate::layers::shared::strip_ansi;

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -92,6 +92,7 @@ pub(crate) struct MetadataV2 {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, CacheDiff)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct MetadataV3 {
     #[cache_diff(rename = "OS Distribution")]
     pub(crate) os_distribution: OsDistribution,


### PR DESCRIPTION
These were added as a part of the RubyConf hackweek, but I just merged that PR in. Between then and now, I added metadata that didn't include the container attribute.

The attribute is described here: https://serde.rs/container-attrs.html.

> Always error during deserialization when encountering unknown fields. When this attribute is not present, by default unknown fields are ignored for self-describing formats like JSON.
>
> Note: this attribute is not supported in combination with [flatten](https://serde.rs/field-attrs.html#flatten), neither on the outer struct nor on the flattened field.

I proposed adding it to all structs here https://github.com/heroku/buildpacks/discussions/23