### PR TITLE
Add support for pre-release ruby versions

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ruby pre-release verssions like `3.4.0.rc1` now work as expected. ([#372](https://github.com/heroku/buildpacks-ruby/pull/372))
 - Layer metadata deserialization to Rust structs is now using `#[serde(deny_unknown_fields)]` this prevents the accidental scenario where metadata containing a superset of fields could accidentally be deserialized to the wrong struct. It's unlikely this is currently happening with the current buildpack, but it's a possibly-observable difference so it's being listed ([#371](https://github.com/heroku/buildpacks-ruby/pull/371))
 
 ## [4.0.1] - 2024-12-11

--- a/commons/src/gemfile_lock.rs
+++ b/commons/src/gemfile_lock.rs
@@ -116,13 +116,12 @@ impl FromStr for GemfileLock {
     type Err = std::convert::Infallible;
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
-        let bundled_with_re = Regex::new("BUNDLED WITH\\s   (\\d+\\.\\d+\\.\\d+)")
-            .expect("Internal error: Bad regex"); // Checked via clippy
+        let bundled_with_re =
+            Regex::new("BUNDLED WITH\\s   (\\d+\\.\\d+\\.\\d+)").expect("Clippy checked");
         let main_ruby_version_re =
             Regex::new("RUBY VERSION\\s   ruby (\\d+\\.\\d+\\.\\d+((-|\\.)\\S*\\d+)?)")
-                .expect("Internal error: Bad regex"); // Checked via clippy
-        let jruby_version_re =
-            Regex::new("\\(jruby ((\\d+|\\.)+)\\)").expect("Internal error: Bad regex"); // Checked via clippy
+                .expect("Clippy checked");
+        let jruby_version_re = Regex::new("\\(jruby ((\\d+|\\.)+)\\)").expect("Clippy checked");
 
         let bundler_version = match bundled_with_re.captures(string).and_then(|c| c.get(1)) {
             Some(result) => BundlerVersion::Explicit(result.as_str().to_string()),

--- a/commons/src/gemfile_lock.rs
+++ b/commons/src/gemfile_lock.rs
@@ -118,8 +118,9 @@ impl FromStr for GemfileLock {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         let bundled_with_re = Regex::new("BUNDLED WITH\\s   (\\d+\\.\\d+\\.\\d+)")
             .expect("Internal error: Bad regex"); // Checked via clippy
-        let main_ruby_version_re = Regex::new("RUBY VERSION\\s   ruby (\\d+\\.\\d+\\.\\d+)")
-            .expect("Internal error: Bad regex"); // Checked via clippy
+        let main_ruby_version_re =
+            Regex::new("RUBY VERSION\\s   ruby (\\d+\\.\\d+\\.\\d+((-|\\.)\\S*\\d+)?)")
+                .expect("Internal error: Bad regex"); // Checked via clippy
         let jruby_version_re =
             Regex::new("\\(jruby ((\\d+|\\.)+)\\)").expect("Internal error: Bad regex"); // Checked via clippy
 
@@ -151,6 +152,75 @@ impl FromStr for GemfileLock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_does_not_capture_patch_version() {
+        let info = GemfileLock::from_str(
+            r"
+RUBY VERSION
+   ruby 3.3.5p100
+
+BUNDLED WITH
+   2.3.4
+",
+        )
+        .unwrap();
+
+        assert_eq!(
+            info.bundler_version,
+            BundlerVersion::Explicit("2.3.4".to_string())
+        );
+        assert_eq!(
+            info.ruby_version,
+            RubyVersion::Explicit("3.3.5".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rc_dot_version() {
+        let info = GemfileLock::from_str(
+            r"
+RUBY VERSION
+   ruby 3.4.0.rc1
+
+BUNDLED WITH
+   2.3.4
+",
+        )
+        .unwrap();
+
+        assert_eq!(
+            info.bundler_version,
+            BundlerVersion::Explicit("2.3.4".to_string())
+        );
+        assert_eq!(
+            info.ruby_version,
+            RubyVersion::Explicit("3.4.0.rc1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_preview_version() {
+        let info = GemfileLock::from_str(
+            r"
+RUBY VERSION
+   ruby 3.4.0.preview2
+
+BUNDLED WITH
+   2.3.4
+",
+        )
+        .unwrap();
+
+        assert_eq!(
+            info.bundler_version,
+            BundlerVersion::Explicit("2.3.4".to_string())
+        );
+        assert_eq!(
+            info.ruby_version,
+            RubyVersion::Explicit("3.4.0.preview2".to_string())
+        );
+    }
 
     #[test]
     fn test_parse_gemfile_lock() {


### PR DESCRIPTION
Pre-releases in ruby use either `-` or `.` and touch the last number, versus patch identifiers start with `p`. This commit now captures identifiers such as `.rc1` or `.preview2`

The state of tooling is confusing, as different tools manipulate values differently:

```
$ cat Gemfile
source 'https://rubygems.org'
ruby "3.4.0-rc1"
gem 'rake'
⛄️ 3.4.0 🚀 /private/tmp/aa82068ba3124d84c76d7faf156888a5 (main)
$ cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    rake (13.2.1)

PLATFORMS
  arm64-darwin-23
  ruby

DEPENDENCIES
  rake

RUBY VERSION
   ruby 3.4.0.rc1

BUNDLED WITH
   2.5.23
```

Here's some more context:

- https://github.com/heroku/docker-heroku-ruby-builder/blob/175b5c15104cb809e1a0adc2c2a9902f94083954/lib/version_parts.rb#L1-L57
- https://github.com/heroku/docker-heroku-ruby-builder/blob/a41f31c72a74df6bcb4f9266e12192b0af83da98/shared/src/download_ruby_version.rs#L73-L93

Our versions are stored on S3 like this:

```
s3://heroku-buildpack-ruby/heroku-24/arm64/ruby-3.4.0.rc1.tgz
```