### PR TITLE
Update default bundler and ruby versions

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default Ruby version is now 3.2.6 ([#374](https://github.com/heroku/buildpacks-ruby/pull/374))
+- Default Bundler version is now 2.5.6 ([#374](https://github.com/heroku/buildpacks-ruby/pull/374))
+
 ## [4.0.2] - 2024-12-16
 
 ### Fixed

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -122,8 +122,8 @@ impl Buildpack for RubyBuildpack {
         let lockfile_contents = fs_err::read_to_string(&lockfile)
             .map_err(|error| RubyBuildpackError::MissingGemfileLock(lockfile, error))?;
         let gemfile_lock = GemfileLock::from_str(&lockfile_contents).expect("Infallible");
-        let bundler_version = gemfile_lock.resolve_bundler("2.4.5");
-        let ruby_version = gemfile_lock.resolve_ruby("3.1.3");
+        let bundler_version = gemfile_lock.resolve_bundler("2.5.6");
+        let ruby_version = gemfile_lock.resolve_ruby("3.2.6");
 
         // ## Install metrics agent
         build_output = {

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -20,7 +20,7 @@ fn test_migrating_metadata() {
     // Remove the return and update the `buildpack-ruby` reference to the latest version.
     #![allow(unreachable_code)]
     // Test v4.0.2 compatible with v4.0.1
-    // return;
+    return;
 
     let builder = "heroku/builder:24";
     let app_dir = "tests/fixtures/default_ruby";

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -148,7 +148,7 @@ fn test_jruby_app() {
         r#"
         source "https://rubygems.org"
 
-        ruby '2.6.8', engine: 'jruby', engine_version: '9.3.6.0'
+        ruby '3.1.4', engine: 'jruby', engine_version: '9.4.8.0'
     "#,
     )
     .unwrap();
@@ -162,7 +162,7 @@ GEM
 PLATFORMS
   java
 RUBY VERSION
-   ruby 2.6.8p001 (jruby 9.3.6.0)
+   ruby 3.1.4p001 (jruby 9.4.8.0)
 DEPENDENCIES
 ",
     )
@@ -183,7 +183,7 @@ DEPENDENCIES
                 context.pack_stdout,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
-            assert_contains!(context.pack_stdout, "Ruby version `2.6.8-jruby-9.3.6.0` from `Gemfile.lock`");
+            assert_contains!(context.pack_stdout, "Ruby version `3.1.4-jruby-9.4.8.0` from `Gemfile.lock`");
             });
 }
 


### PR DESCRIPTION
Rails 8.0.1 needs Ruby 3.2+ and unfortunately they decided to stop shipping with a Ruby version in the Gemfile. I don't yet have `.ruby-version` support, but this will at least allow a `rails new` app to work on Heroku with the default versions.