### PR TITLE
Add ability to migrate layer names and change `ruby` to `binruby`

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Binaries from user installed gems will be placed on the path before binaries that ship with Ruby ([#382](https://github.com/heroku/buildpacks-ruby/pull/382))
+
 ## [5.0.0] - 2024-12-17
 
 ### Changed

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -20,7 +20,7 @@ use bullet_stream::state::SubBullet;
 use bullet_stream::Print;
 use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedRubyVersion;
-use commons::layer::diff_migrate::DiffMigrateLayer;
+use commons::layer::diff_migrate::{DiffMigrateLayer, LayerRename};
 use flate2::read::GzDecoder;
 use libcnb::data::layer_name;
 use libcnb::layer::{EmptyLayerCause, LayerState};
@@ -42,7 +42,14 @@ pub(crate) fn handle(
         build: true,
         launch: true,
     }
-    .cached_layer(layer_name!("ruby"), context, metadata)?;
+    .cached_layer_rename(
+        LayerRename {
+            to: layer_name!("binruby"),
+            from: vec![layer_name!("ruby")],
+        },
+        context,
+        metadata,
+    )?;
     match &layer_ref.state {
         LayerState::Restored { cause } => {
             bullet = bullet.sub_bullet(cause);

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -74,6 +74,11 @@ fn test_default_app_ubuntu20() {
             indoc! {"
                 set -euo pipefail
                 printenv | sort | grep -vE '(_|HOME|HOSTNAME|OLDPWD|PWD|SHLVL|SECRET_KEY_BASE)='
+
+                # Output command + output to stdout
+                export BASH_XTRACEFD=1; set -o xtrace
+                which -a rake
+                which -a ruby
             "}
         );
         assert_empty!(command_output.stderr);
@@ -96,6 +101,15 @@ fn test_default_app_ubuntu20() {
                 RAILS_ENV=production
                 RAILS_LOG_TO_STDOUT=enabled
                 RAILS_SERVE_STATIC_FILES=enabled
+                + which -a rake
+                /layers/heroku_ruby/gems/bin/rake
+                /layers/heroku_ruby/binruby/bin/rake
+                /usr/bin/rake
+                /bin/rake
+                + which -a ruby
+                /layers/heroku_ruby/binruby/bin/ruby
+                /usr/bin/ruby
+                /bin/ruby
             "}
         );
         },

--- a/commons/CHANGELOG.md
+++ b/commons/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Added
 
+- Introduce `DiffMigrateLayer::cached_layer_rename` and `layer::diff_migrate::LayerRename` (https://github.com/heroku/buildpacks-ruby/pull/382)
+
+## 2024-01-08
+
+### Added
+
 - Introduced `layer::diff_migrate` and `DiffMigrateLayer` for public cache use (https://github.com/heroku/buildpacks-ruby/pull/376)
 
 ### Changed

--- a/commons/src/layer/diff_migrate.rs
+++ b/commons/src/layer/diff_migrate.rs
@@ -143,6 +143,24 @@ pub struct LayerRename {
     pub from: Vec<LayerName>,
 }
 
+fn copy_recursive_from_to(from_dir: &Path, to_path: &Path) -> Result<(), std::io::Error> {
+    fs_err::create_dir_all(&to_path)?;
+
+    for prior in walkdir::WalkDir::new(&from_dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let relative = prior
+            .path()
+            .strip_prefix(&from_dir)
+            .expect("path is within given directory");
+
+        fs_err::copy(prior.path(), to_path.join(relative))?;
+    }
+    Ok(())
+}
+
 /// Returns Some(PathBuf) when the layer exists on disk
 fn is_layer_on_disk<B>(
     layer_name: &LayerName,

--- a/commons/src/layer/diff_migrate.rs
+++ b/commons/src/layer/diff_migrate.rs
@@ -130,6 +130,15 @@ impl DiffMigrateLayer {
     }
 }
 
+/// Represents when we want to move contents from one (or more) layer names
+///
+pub struct LayerRename {
+    /// The desired layer name
+    pub to: LayerName,
+    /// A list of prior, possibly layer names
+    pub from: Vec<LayerName>,
+}
+
 /// Standardizes formatting for layer cache clearing behavior
 ///
 /// If the diff is empty, there are no changes and the layer is kept and the old data is returned

--- a/docs/application_contract.md
+++ b/docs/application_contract.md
@@ -80,5 +80,6 @@ Once an application has passed the detect phase, the build phase will execute to
   - `GEM_PATH=<bundle-path-dir>` - Tells Ruby where gems are located.
   - `MALLOC_ARENA_MAX=2` - Controls glibc memory allocation behavior with the goal of decreasing overall memory allocated by Ruby [details](https://devcenter.heroku.com/changelog-items/1683).
   - `PATH` - Various executables are installed and the `PATH` env var will be modified so they can be executed at the system level. This is mostly done via interfaces provided by `libcnb` and CNB layers rather than directly.
+    - Binaries from gems will take precedence over binaries that ship with Ruby (for example `rake` installed from `bundle install` should be loaded before `rake` that come with the compiled Ruby binary).
   - `RAILS_LOG_TO_STDOUT="enabled"` - Sets the default logging target to STDOUT for Rails 5+ apps. [details](https://blog.heroku.com/container_ready_rails_5)
   - `RAILS_SERVE_STATIC_FILES="enabled"` - Enables the `ActionDispatch::Static` middleware for Rails 5+ apps so that static files such as those in `public/assets` are served by the Ruby webserver such as Puma [details](https://blog.heroku.com/container_ready_rails_5).


### PR DESCRIPTION
Issue https://github.com/heroku/buildpacks-ruby/issues/380 showed that the system ruby binaries are being loaded in front of the user installed gems which is causing problems.

This PR introduces a new method `cached_layer_rename` and a new struct `LayerRename` which allows a buildpack author to retain the contents of a prior layer. This functionality is then used to rename `ruby` to `binruby` which causes it to alphabetically come before `gems` which means that env vars from `gems` will be be applied last (take precedence).

Commits are small and mostly in order.