### PR TITLE
Use global print output

### DIFF
--- a/buildpacks/ruby/src/gem_list.rs
+++ b/buildpacks/ruby/src/gem_list.rs
@@ -5,7 +5,7 @@ use fun_run::CmdError;
 use regex::Regex;
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::io::Stdout;
+use std::io::Write;
 use std::process::Command;
 
 /// ## Gets list of an application's dependencies
@@ -21,11 +21,12 @@ pub(crate) struct GemList {
 /// # Errors
 ///
 /// Errors if the command `bundle list` is unsuccessful.
-pub(crate) fn bundle_list<T, K, V>(
-    mut bullet: Print<SubBullet<Stdout>>,
+pub(crate) fn bundle_list<W, T, K, V>(
+    mut bullet: Print<SubBullet<W>>,
     envs: T,
-) -> Result<(Print<SubBullet<Stdout>>, GemList), CmdError>
+) -> Result<(Print<SubBullet<W>>, GemList), CmdError>
 where
+    W: Write + Send + Sync + 'static,
     T: IntoIterator<Item = (K, V)>,
     K: AsRef<OsStr>,
     V: AsRef<OsStr>,

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -18,16 +18,19 @@ use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Env;
 use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
-use std::io::Stdout;
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) fn handle(
+pub(crate) fn handle<W>(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
-    mut bullet: Print<SubBullet<Stdout>>,
+    mut bullet: Print<SubBullet<W>>,
     metadata: &Metadata,
-) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
+) -> libcnb::Result<(Print<SubBullet<W>>, LayerEnv), RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let layer_ref = DiffMigrateLayer {
         build: true,
         launch: true,
@@ -79,12 +82,15 @@ pub(crate) struct MetadataV1 {
     pub(crate) version: ResolvedBundlerVersion,
 }
 
-fn download_bundler(
-    mut bullet: Print<SubBullet<Stdout>>,
+fn download_bundler<W>(
+    mut bullet: Print<SubBullet<W>>,
     env: &Env,
     metadata: &Metadata,
     gem_path: &Path,
-) -> Result<Print<SubBullet<Stdout>>, RubyBuildpackError> {
+) -> Result<Print<SubBullet<W>>, RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let bin_dir = gem_path.join("bin");
 
     let mut cmd = Command::new("gem");

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -32,7 +32,7 @@ use libcnb::{
 };
 use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
-use std::io::Stdout;
+use std::io::Write;
 use std::{path::Path, process::Command};
 
 /// When this environment variable is set, the `bundle install` command will always
@@ -44,13 +44,16 @@ const SKIP_DIGEST_ENV_KEY: &str = "HEROKU_SKIP_BUNDLE_DIGEST";
 /// on the next build.
 pub(crate) const FORCE_BUNDLE_INSTALL_CACHE_KEY: &str = "v1";
 
-pub(crate) fn handle(
+pub(crate) fn handle<W>(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
-    mut bullet: Print<SubBullet<Stdout>>,
+    mut bullet: Print<SubBullet<W>>,
     metadata: &Metadata,
     without: &BundleWithout,
-) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
+) -> libcnb::Result<(Print<SubBullet<W>>, LayerEnv), RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let layer_ref = DiffMigrateLayer {
         build: true,
         launch: true,

--- a/buildpacks/ruby/src/layers/metrics_agent_install.rs
+++ b/buildpacks/ruby/src/layers/metrics_agent_install.rs
@@ -9,7 +9,7 @@ use libcnb::layer::{
 };
 use libherokubuildpack::digest::sha256;
 use serde::{Deserialize, Serialize};
-use std::io::Stdout;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use tar::Archive;
@@ -60,10 +60,13 @@ pub(crate) enum MetricsAgentInstallError {
     ChecksumFailed(String),
 }
 
-pub(crate) fn handle_metrics_agent_layer(
+pub(crate) fn handle_metrics_agent_layer<W>(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
-    mut bullet: Print<SubBullet<Stdout>>,
-) -> libcnb::Result<Print<SubBullet<Stdout>>, RubyBuildpackError> {
+    mut bullet: Print<SubBullet<W>>,
+) -> libcnb::Result<Print<SubBullet<W>>, RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let metadata = Metadata {
         download_url: DOWNLOAD_URL.to_string(),
     };

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -27,17 +27,20 @@ use libcnb::layer::{EmptyLayerCause, LayerState};
 use libcnb::layer_env::LayerEnv;
 use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
-use std::io::{self, Stdout};
+use std::io::Write;
 use std::path::Path;
 use tar::Archive;
 use tempfile::NamedTempFile;
 use url::Url;
 
-pub(crate) fn handle(
+pub(crate) fn handle<W>(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
-    mut bullet: Print<SubBullet<Stdout>>,
+    mut bullet: Print<SubBullet<W>>,
     metadata: &Metadata,
-) -> libcnb::Result<(Print<SubBullet<Stdout>>, LayerEnv), RubyBuildpackError> {
+) -> libcnb::Result<(Print<SubBullet<W>>, LayerEnv), RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let layer_ref = DiffMigrateLayer {
         build: true,
         launch: true,
@@ -198,7 +201,7 @@ pub(crate) fn download(
     let mut destination_file = fs_err::File::create(destination.as_ref())
         .map_err(RubyInstallError::CouldNotCreateDestinationFile)?;
 
-    io::copy(&mut response_reader, &mut destination_file)
+    std::io::copy(&mut response_reader, &mut destination_file)
         .map_err(RubyInstallError::CouldNotWriteDestinationFile)?;
 
     Ok(())

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -18,7 +18,6 @@ use libcnb::layer::UncachedLayerDefinition;
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Platform;
 use libcnb::{buildpack_main, Buildpack};
-use std::io::stdout;
 
 mod gem_list;
 mod layers;

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -115,7 +115,7 @@ impl Buildpack for RubyBuildpack {
 
     #[allow(clippy::too_many_lines)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-        let mut build_output = Print::new(stdout()).h2("Heroku Ruby Buildpack");
+        let mut build_output = Print::global().h2("Heroku Ruby Buildpack");
 
         // ## Set default environment
         let (mut env, store) =

--- a/buildpacks/ruby/src/rake_task_detect.rs
+++ b/buildpacks/ruby/src/rake_task_detect.rs
@@ -1,7 +1,7 @@
 use bullet_stream::{state::SubBullet, Print};
 use core::str::FromStr;
 use fun_run::CmdError;
-use std::io::Stdout;
+use std::io::Write;
 use std::{ffi::OsStr, process::Command};
 
 /// Run `rake -P` and parse output to show what rake tasks an application has
@@ -21,11 +21,17 @@ pub(crate) struct RakeDetect {
 /// # Errors
 ///
 /// Will return `Err` if `bundle exec rake -p` command cannot be invoked by the operating system.
-pub(crate) fn call<T: IntoIterator<Item = (K, V)>, K: AsRef<OsStr>, V: AsRef<OsStr>>(
-    mut bullet: Print<SubBullet<Stdout>>,
+pub(crate) fn call<W, T, K, V>(
+    mut bullet: Print<SubBullet<W>>,
     envs: T,
     error_on_failure: bool,
-) -> Result<(Print<SubBullet<Stdout>>, RakeDetect), CmdError> {
+) -> Result<(Print<SubBullet<W>>, RakeDetect), CmdError>
+where
+    W: Write + Send + Sync + 'static,
+    T: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
     let mut cmd = Command::new("rake");
     cmd.args(["-P", "--trace"]).env_clear().envs(envs);
 

--- a/buildpacks/ruby/src/steps/detect_rake_tasks.rs
+++ b/buildpacks/ruby/src/steps/detect_rake_tasks.rs
@@ -7,14 +7,17 @@ use bullet_stream::state::SubBullet;
 use bullet_stream::{style, Print};
 use libcnb::build::BuildContext;
 use libcnb::Env;
-use std::io::Stdout;
+use std::io::Write;
 
-pub(crate) fn detect_rake_tasks(
-    bullet: Print<SubBullet<Stdout>>,
+pub(crate) fn detect_rake_tasks<W>(
+    bullet: Print<SubBullet<W>>,
     gem_list: &GemList,
     context: &BuildContext<RubyBuildpack>,
     env: &Env,
-) -> Result<(Print<SubBullet<Stdout>>, Option<RakeDetect>), RubyBuildpackError> {
+) -> Result<(Print<SubBullet<W>>, Option<RakeDetect>), RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let help = style::important("HELP");
     let rake = style::value("rake");
     let gemfile = style::value("Gemfile");

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -6,14 +6,17 @@ use libcnb::build::BuildContext;
 use libcnb::data::launch::Process;
 use libcnb::data::launch::ProcessBuilder;
 use libcnb::data::process_type;
-use std::io::Stdout;
+use std::io::Write;
 use std::path::Path;
 
-pub(crate) fn get_default_process(
-    bullet: Print<SubBullet<Stdout>>,
+pub(crate) fn get_default_process<W>(
+    bullet: Print<SubBullet<W>>,
     context: &BuildContext<RubyBuildpack>,
     gem_list: &GemList,
-) -> (Print<SubBullet<Stdout>>, Option<Process>) {
+) -> (Print<SubBullet<W>>, Option<Process>)
+where
+    W: Write + Send + Sync + 'static,
+{
     let config_ru = style::value("config.ru");
     let rails = style::value("rails");
     let rack = style::value("rack");

--- a/buildpacks/ruby/src/steps/rake_assets_install.rs
+++ b/buildpacks/ruby/src/steps/rake_assets_install.rs
@@ -6,15 +6,18 @@ use bullet_stream::{style, Print};
 use commons::cache::{mib, AppCache, CacheConfig, CacheError, CacheState, KeepPath, PathState};
 use libcnb::build::BuildContext;
 use libcnb::Env;
-use std::io::Stdout;
+use std::io::Write;
 use std::process::Command;
 
-pub(crate) fn rake_assets_install(
-    mut bullet: Print<SubBullet<Stdout>>,
+pub(crate) fn rake_assets_install<W>(
+    mut bullet: Print<SubBullet<W>>,
     context: &BuildContext<RubyBuildpack>,
     env: &Env,
     rake_detect: &RakeDetect,
-) -> Result<Print<SubBullet<Stdout>>, RubyBuildpackError> {
+) -> Result<Print<SubBullet<W>>, RubyBuildpackError>
+where
+    W: Write + Send + Sync + 'static,
+{
     let help = style::important("HELP");
     let cases = asset_cases(rake_detect);
     let rake_assets_precompile = style::value("rake assets:precompile");

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 const DEBUG_INFO_STR: &str = "Debug info";
 
 pub(crate) fn on_error(err: libcnb::Error<RubyBuildpackError>) {
-    let output = Print::new(std::io::stdout()).without_header();
+    let output = Print::global().without_header();
     let debug_info = style::important(DEBUG_INFO_STR);
     match cause(err) {
         Cause::OurError(error) => log_our_error(output, error),

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -2,7 +2,7 @@ use crate::{DetectError, RubyBuildpackError};
 use bullet_stream::{state::Bullet, state::SubBullet, style, Print};
 use fun_run::CmdError;
 use indoc::formatdoc;
-use std::io::Stdout;
+use std::io::Write;
 use std::process::Command;
 const DEBUG_INFO_STR: &str = "Debug info";
 
@@ -34,7 +34,10 @@ pub(crate) fn on_error(err: libcnb::Error<RubyBuildpackError>) {
 }
 
 #[allow(clippy::too_many_lines)]
-fn log_our_error(mut output: Print<Bullet<Stdout>>, error: RubyBuildpackError) {
+fn log_our_error<W: Write + Send + Sync + 'static>(
+    mut output: Print<Bullet<W>>,
+    error: RubyBuildpackError,
+) {
     let git_branch_url =
         style::url("https://devcenter.heroku.com/articles/git#deploy-from-a-branch-besides-main");
     let ruby_versions_url =
@@ -340,7 +343,10 @@ fn replace_app_path_with_relative(contents: impl AsRef<str>) -> String {
     app_path_re.replace_all(contents.as_ref(), "./").to_string()
 }
 
-fn debug_cmd(mut log: Print<SubBullet<Stdout>>, command: &mut Command) -> Print<Bullet<Stdout>> {
+fn debug_cmd<W: Write + Send + Sync + 'static>(
+    mut log: Print<SubBullet<W>>,
+    command: &mut Command,
+) -> Print<Bullet<W>> {
     match log.stream_cmd(command) {
         Ok(_) => log.done(),
         Err(e) => log.sub_bullet(e.to_string()).done(),

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -34,22 +34,22 @@ fn test_migrating_metadata_or_layer_names() {
             "docker://docker.io/heroku/buildpack-ruby:5.0.0".to_string(),
         )]),
         |context| {
-            println!("{}", context.pack_stdout);
+            println!("{}", context.pack_stderr);
             context.rebuild(
                 BuildConfig::new(builder, app_dir).buildpacks([BuildpackReference::CurrentCrate]),
                 |rebuild_context| {
-                    println!("{}", rebuild_context.pack_stdout);
+                    println!("{}", rebuild_context.pack_stderr);
 
                     assert_contains_match!(
-                        rebuild_context.pack_stdout,
+                        rebuild_context.pack_stderr,
                         r"^- Ruby version[^\n]*\n  - Using cache"
                     );
                     assert_contains_match!(
-                        rebuild_context.pack_stdout,
+                        rebuild_context.pack_stderr,
                         r"^- Bundler version[^\n]*\n  - Using cache"
                     );
                     assert_contains_match!(
-                        rebuild_context.pack_stdout,
+                        rebuild_context.pack_stderr,
                         r"^- Bundle install gems[^\n]*\n  - Using cache"
                     );
                 },
@@ -77,13 +77,13 @@ fn test_default_app_ubuntu20() {
     TestRunner::default().build(
         config.clone(),
         |context| {
-            println!("{}", context.pack_stdout);
-            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
 
-            assert_contains!(context.pack_stdout, "Installing puma");
+            assert_contains!(context.pack_stderr, "Installing puma");
 
         // Check that at run-time:
         // - The correct env vars are set.
@@ -184,9 +184,9 @@ fn test_default_app_ubuntu20() {
 
 
         context.rebuild(config, |rebuild_context| {
-            println!("{}", rebuild_context.pack_stdout);
-            assert_contains!(rebuild_context.pack_stdout, "Skipping `bundle install` (no changes found in /workspace/Gemfile, /workspace/Gemfile.lock, or user configured environment variables)");
-            let rake_output = Regex::new(r"(?sm)START RAKE TEST OUTPUT\n(.*)END RAKE TEST OUTPUT").unwrap().captures(&rebuild_context.pack_stdout).and_then(|captures| captures.get(1).map(|m| m.as_str().to_string())).unwrap();
+            println!("{}", rebuild_context.pack_stderr);
+            assert_contains!(rebuild_context.pack_stderr, "Skipping `bundle install` (no changes found in /workspace/Gemfile, /workspace/Gemfile.lock, or user configured environment variables)");
+            let rake_output = Regex::new(r"(?sm)START RAKE TEST OUTPUT\n(.*)END RAKE TEST OUTPUT").unwrap().captures(&rebuild_context.pack_stderr).and_then(|captures| captures.get(1).map(|m| m.as_str().to_string())).unwrap();
             assert_eq!(
                 r"
       $ echo $PATH
@@ -236,13 +236,13 @@ fn test_default_app_ubuntu22() {
     TestRunner::default().build(
         BuildConfig::new("heroku/builder:22", "tests/fixtures/default_ruby"),
         |context| {
-            println!("{}", context.pack_stdout);
-            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
 
-            assert_contains!(context.pack_stdout, "Installing puma");
+            assert_contains!(context.pack_stderr, "Installing puma");
         },
     );
 }
@@ -255,21 +255,21 @@ fn test_default_app_latest_distro() {
     TestRunner::default().build(
         config,
         |context| {
-            println!("{}", context.pack_stdout);
-            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
 
-            assert_contains!(context.pack_stdout, "Installing puma");
+            assert_contains!(context.pack_stderr, "Installing puma");
 
             let secret_key_base = context.run_shell_command("echo \"${SECRET_KEY_BASE:?No SECRET_KEY_BASE set}\"").stdout;
             assert!(!secret_key_base.trim().is_empty(), "Expected {secret_key_base:?} to not be empty but it is");
 
             let config = context.config.clone();
             context.rebuild(config, |rebuild_context| {
-                println!("{}", rebuild_context.pack_stdout);
-                assert_contains!(rebuild_context.pack_stdout, "Skipping `bundle install` (no changes found in /workspace/Gemfile, /workspace/Gemfile.lock, or user configured environment variables)");
+                println!("{}", rebuild_context.pack_stderr);
+                assert_contains!(rebuild_context.pack_stderr, "Skipping `bundle install` (no changes found in /workspace/Gemfile, /workspace/Gemfile.lock, or user configured environment variables)");
 
                 rebuild_context.start_container(
                     ContainerConfig::new()
@@ -336,13 +336,13 @@ DEPENDENCIES
             BuildpackReference::CurrentCrate,
         ]),
         |context| {
-            println!("{}", context.pack_stdout);
-            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
-            assert_contains!(context.pack_stdout, "Ruby version `3.1.4-jruby-9.4.8.0` from `Gemfile.lock`");
+            assert_contains!(context.pack_stderr, "Ruby version `3.1.4-jruby-9.4.8.0` from `Gemfile.lock`");
             });
 }
 
@@ -357,10 +357,10 @@ fn test_ruby_app_with_yarn_app() {
             BuildpackReference::CurrentCrate,
         ]),
         |context| {
-            println!("{}", context.pack_stdout);
-            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 r#"`BUNDLE_BIN="/layers/heroku_ruby/gems/bin" BUNDLE_CLEAN="1" BUNDLE_DEPLOYMENT="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_PATH="/layers/heroku_ruby/gems" BUNDLE_WITHOUT="development:test" bundle install`"#);
             }
         );
@@ -372,9 +372,9 @@ fn test_barnes_app() {
     TestRunner::default().build(
         BuildConfig::new("heroku/builder:22", "tests/fixtures/barnes_app"),
         |context| {
-            println!("{}", context.pack_stdout);
+            println!("{}", context.pack_stderr);
 
-            assert_contains!(context.pack_stdout, "Installing metrics agent from https://agentmon-releases.s3.us-east-1.amazonaws.com/agentmon");
+            assert_contains!(context.pack_stderr, "Installing metrics agent from https://agentmon-releases.s3.us-east-1.amazonaws.com/agentmon");
             context.start_container(
                 ContainerConfig::new()
                     .entrypoint("launcher")


### PR DESCRIPTION
Switches from stdout to the global writer which defaults to stderr. This swich guarantees consistent print output when the print stream is dropped and then we have to construct a new one to emit an error message.