### PR TITLE
Set an explicit PR reviewer for CNB builder release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,4 +1,4 @@
-name: Prepare Buildpack Releases
+name: Prepare Buildpack Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Buildpacks
+name: Release Buildpack
 
 on:
   workflow_dispatch:
@@ -15,6 +15,7 @@ jobs:
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
       dry_run: ${{ inputs.dry_run }}
+      reviewers: 'schneems'
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Currently for CNB releases, the PR opened against `cnb-builder-images` doesn't have an explicit reviewer set by the automation, which means it uses that repo's `CODEOWNERS` default of requesting review from the whole Languages team.

As of https://github.com/heroku/languages-github-actions/pull/289, the automation now supports passing a list of reviewers, which we can set for CNBs owned by a specific language owner.

This will help reduce review-request-spam to other team members.

Plus corrects the workflow names given this repo contains only a single CNB.

GUS-W-18011095.