### PR TITLE
Add cargo-llvm-cov test coverage reports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,28 @@ jobs:
         run: pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --buildpack heroku/nodejs-engine --buildpack packaged/${{ matrix.target }}/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
       - name: "PRINT: Cached getting started guide output"
         run: pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --buildpack heroku/nodejs-engine --buildpack packaged/${{ matrix.target }}/debug/heroku_ruby --path tmp/ruby-getting-started --pull-policy never
+
+  unit-test-coverage:
+    name: Generate test coverage report
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install nightly Rust toolchain
+        run: rustup install nightly
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: cargo-llvm-cov
+      - name: Run unit tests and generate coverage report
+        run: cargo +nightly llvm-cov --locked --html
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: "llvm-cov-html-${{github.event.repository.name}}-${{github.sha}}"
+          path: "target/llvm-cov/html"
+          if-no-files-found: "error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ unreachable_pub = "warn"
 unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
+# Allows the usage of cfg(coverage_nightly).
+# cargo-llvm-cov enables that config when instrumenting our code, so we can enable
+# the experimental coverage_attribute feature.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+
 [workspace.lints.clippy]
 panic_in_result_fn = "warn"
 # The explicit priority is required due to https://github.com/rust-lang/cargo/issues/13565.

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use bullet_stream::{style, Print};
 use commons::cache::CacheError;
 use commons::gemfile_lock::GemfileLock;

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 pub mod cache;
 pub mod display;
 pub mod gem_version;


### PR DESCRIPTION
Related:

- https://github.com/heroku/buildpacks-jvm/pull/766
- https://github.com/heroku/buildpacks-go/pull/349

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/e75d43c2-df5d-4cf0-b70a-9ff6c80587b5" />

GUS-W-18109363