### PR TITLE
Switch to the bullet_stream function interface (instead of type-state "streaming" interface)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "bullet_stream"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a257795d84e5eb8b6eff8b2655ef4fe043d006888788bfc9905611d15b187a"
+checksum = "adc54f3252b0ff30201f78a466a017afef4da0ec6c669efcabef8d4cec7c0d58"
 dependencies = [
  "fun_run",
 ]

--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Internal API used for producing buildpack output updated. ([#419](https://github.com/heroku/buildpacks-ruby/pull/419))
+
 ## [7.0.1] - 2025-04-09
 
 ### Added

--- a/buildpacks/ruby/src/gem_list.rs
+++ b/buildpacks/ruby/src/gem_list.rs
@@ -1,12 +1,10 @@
 use bullet_stream::global::print;
-use bullet_stream::{state::SubBullet, Print};
 use commons::gem_version::GemVersion;
 use core::str::FromStr;
 use fun_run::CmdError;
 use regex::Regex;
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::io::Write;
 use std::process::Command;
 
 /// ## Gets list of an application's dependencies

--- a/buildpacks/ruby/src/gem_list.rs
+++ b/buildpacks/ruby/src/gem_list.rs
@@ -1,3 +1,4 @@
+use bullet_stream::global::print;
 use bullet_stream::{state::SubBullet, Print};
 use commons::gem_version::GemVersion;
 use core::str::FromStr;
@@ -21,12 +22,8 @@ pub(crate) struct GemList {
 /// # Errors
 ///
 /// Errors if the command `bundle list` is unsuccessful.
-pub(crate) fn bundle_list<W, T, K, V>(
-    mut bullet: Print<SubBullet<W>>,
-    envs: T,
-) -> Result<(Print<SubBullet<W>>, GemList), CmdError>
+pub(crate) fn bundle_list<T, K, V>(envs: T) -> Result<GemList, CmdError>
 where
-    W: Write + Send + Sync + 'static,
     T: IntoIterator<Item = (K, V)>,
     K: AsRef<OsStr>,
     V: AsRef<OsStr>,
@@ -34,11 +31,9 @@ where
     let mut cmd = Command::new("bundle");
     cmd.arg("list").env_clear().envs(envs);
 
-    let gem_list = bullet
-        .time_cmd(&mut cmd)
+    print::sub_time_cmd(&mut cmd)
         .map(|output| output.stdout_lossy())
-        .and_then(|output| GemList::from_str(&output))?;
-    Ok((bullet, gem_list))
+        .and_then(|output| GemList::from_str(&output))
 }
 
 /// Converts the output of `$ gem list` into a data structure that can be inspected and compared

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -6,6 +6,7 @@
 //! `<layer-dir>/bin`. Must run before [`crate.steps.bundle_install`].
 use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
+use bullet_stream::global::print;
 use bullet_stream::state::SubBullet;
 use bullet_stream::Print;
 use cache_diff::CacheDiff;
@@ -56,14 +57,14 @@ where
     layer_ref.write_env(&layer_env)?;
     match &layer_ref.state {
         LayerState::Restored { cause } => {
-            bullet = bullet.sub_bullet(cause);
+            print::sub_bullet(cause);
         }
         LayerState::Empty { cause } => {
             match cause {
                 EmptyLayerCause::NewlyCreated => {}
                 EmptyLayerCause::InvalidMetadataAction { cause }
                 | EmptyLayerCause::RestoredLayerAction { cause } => {
-                    bullet = bullet.sub_bullet(cause);
+                    print::sub_bullet(cause);
                 }
             }
             bullet = download_bundler(bullet, env, &metadata.version, &layer_ref.path())

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -64,7 +64,7 @@ pub(crate) fn handle(
                 .map_err(RubyBuildpackError::GemInstallBundlerCommandError)?;
         }
     }
-    Ok(layer_ref.read_env()?)
+    layer_ref.read_env()
 }
 
 pub(crate) type Metadata = MetadataV1;

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Command;
 
-pub(crate) fn handle(
+pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
     metadata: &Metadata,

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -101,9 +101,6 @@ where
     cmd.args(["--version", &version.to_string()]) // Specify exact version to install
         .env_clear()
         .envs(env);
-
-    let short_name = fun_run::display(&mut cmd); // Format `gem install --version <version>` without other content for display
-
     cmd.args(["--install-dir", &format!("{}", gem_path.display())]); // Directory where bundler's contents will live
     cmd.args(["--bindir", &format!("{}", bin_dir.display())]); // Directory where `bundle` executable lives
     cmd.args([
@@ -112,11 +109,9 @@ where
         "--env-shebang", // Start the `bundle` executable with `#! /usr/bin/env ruby`
     ]);
 
-    bullet
-        .time_cmd(&mut cmd.named(short_name))
-        .map_err(|error| {
-            fun_run::map_which_problem(error, cmd.mut_cmd(), env.get("PATH").cloned())
-        })?;
+    print::sub_time_cmd(&mut cmd).map_err(|error| {
+        fun_run::map_which_problem(error, cmd.mut_cmd(), env.get("PATH").cloned())
+    })?;
 
     Ok(bullet)
 }

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -42,7 +42,7 @@ const SKIP_DIGEST_ENV_KEY: &str = "HEROKU_SKIP_BUNDLE_DIGEST";
 /// on the next build.
 pub(crate) const FORCE_BUNDLE_INSTALL_CACHE_KEY: &str = "v2";
 
-pub(crate) fn handle(
+pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
     metadata: &Metadata,

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -117,7 +117,7 @@ pub(crate) fn handle(
         }
     }
 
-    Ok(layer_ref.read_env()?)
+    layer_ref.read_env()
 }
 
 pub(crate) type Metadata = MetadataV3;

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -84,11 +84,11 @@ pub(crate) fn handle(
             }
 
             let mut cmd = Command::new("bundle");
-            cmd.args(["install"])
+            cmd.arg("install")
                 .env_clear() // Current process env vars already merged into env
                 .envs(&env);
 
-            print::sub_stream_cmd(&mut cmd)
+            print::sub_stream_cmd(cmd.named_fn(|cmd| display_name(cmd, &env)))
                 .map_err(|error| {
                     fun_run::map_which_problem(error, cmd.mut_cmd(), env.get("PATH").cloned())
                 })

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -16,9 +16,7 @@
 //! we must clear the cache and re-run `bundle install`.
 use crate::target_id::{OsDistribution, TargetId, TargetIdError};
 use crate::{BundleWithout, RubyBuildpack, RubyBuildpackError};
-use bullet_stream::global::print;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::{global::print, style};
 use cache_diff::CacheDiff;
 use commons::layer::diff_migrate::{DiffMigrateLayer, Meta};
 use commons::{
@@ -33,7 +31,6 @@ use libcnb::{
 };
 use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use std::{path::Path, process::Command};
 
 /// When this environment variable is set, the `bundle install` command will always
@@ -45,16 +42,12 @@ const SKIP_DIGEST_ENV_KEY: &str = "HEROKU_SKIP_BUNDLE_DIGEST";
 /// on the next build.
 pub(crate) const FORCE_BUNDLE_INSTALL_CACHE_KEY: &str = "v2";
 
-pub(crate) fn handle<W>(
+pub(crate) fn handle(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
-    mut bullet: Print<SubBullet<W>>,
     metadata: &Metadata,
     without: &BundleWithout,
-) -> libcnb::Result<(Print<SubBullet<W>>, LayerEnv), RubyBuildpackError>
-where
-    W: Write + Send + Sync + 'static,
-{
+) -> libcnb::Result<LayerEnv, RubyBuildpackError> {
     let layer_ref = DiffMigrateLayer {
         build: true,
         launch: true,
@@ -124,7 +117,7 @@ where
         }
     }
 
-    Ok((bullet, layer_ref.read_env()?))
+    Ok(layer_ref.read_env()?)
 }
 
 pub(crate) type Metadata = MetadataV3;

--- a/buildpacks/ruby/src/layers/metrics_agent_install.rs
+++ b/buildpacks/ruby/src/layers/metrics_agent_install.rs
@@ -1,7 +1,5 @@
 use crate::{RubyBuildpack, RubyBuildpackError};
-use bullet_stream::global::print;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::{global::print, style};
 use flate2::read::GzDecoder;
 use libcnb::additional_buildpack_binary_path;
 use libcnb::data::layer_name;
@@ -10,7 +8,6 @@ use libcnb::layer::{
 };
 use libherokubuildpack::digest::sha256;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use tar::Archive;
@@ -61,13 +58,9 @@ pub(crate) enum MetricsAgentInstallError {
     ChecksumFailed(String),
 }
 
-pub(crate) fn handle_metrics_agent_layer<W>(
+pub(crate) fn handle_metrics_agent_layer(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
-    mut bullet: Print<SubBullet<W>>,
-) -> libcnb::Result<Print<SubBullet<W>>, RubyBuildpackError>
-where
-    W: Write + Send + Sync + 'static,
-{
+) -> libcnb::Result<(), RubyBuildpackError> {
     let metadata = Metadata {
         download_url: DOWNLOAD_URL.to_string(),
     };
@@ -126,7 +119,7 @@ where
             layer_ref.write_metadata(metadata)?;
         }
     }
-    Ok(bullet)
+    Ok(())
 }
 
 fn write_execd_script(

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -16,6 +16,7 @@ use crate::{
     target_id::{TargetId, TargetIdError},
     RubyBuildpack, RubyBuildpackError,
 };
+use bullet_stream::global::print;
 use bullet_stream::state::SubBullet;
 use bullet_stream::Print;
 use cache_diff::CacheDiff;
@@ -55,19 +56,19 @@ where
     )?;
     match &layer_ref.state {
         LayerState::Restored { cause } => {
-            bullet = bullet.sub_bullet(cause);
+            print::sub_bullet(cause);
         }
         LayerState::Empty { cause } => {
             match cause {
                 EmptyLayerCause::NewlyCreated => {}
                 EmptyLayerCause::InvalidMetadataAction { cause }
                 | EmptyLayerCause::RestoredLayerAction { cause } => {
-                    bullet = bullet.sub_bullet(cause);
+                    print::sub_bullet(cause);
                 }
             }
-            let timer = bullet.start_timer("Installing");
+            let timer = print::sub_start_timer("Installing");
             install_ruby(metadata, &layer_ref.path())?;
-            bullet = timer.done();
+            _ = timer.done();
         }
     }
     Ok((bullet, layer_ref.read_env()?))

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -31,7 +31,7 @@ use tar::Archive;
 use tempfile::NamedTempFile;
 use url::Url;
 
-pub(crate) fn handle(
+pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     metadata: &Metadata,
 ) -> libcnb::Result<LayerEnv, RubyBuildpackError> {

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -17,8 +17,6 @@ use crate::{
     RubyBuildpack, RubyBuildpackError,
 };
 use bullet_stream::global::print;
-use bullet_stream::state::SubBullet;
-use bullet_stream::Print;
 use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedRubyVersion;
 use commons::layer::diff_migrate::{DiffMigrateLayer, LayerRename};
@@ -28,20 +26,15 @@ use libcnb::layer::{EmptyLayerCause, LayerState};
 use libcnb::layer_env::LayerEnv;
 use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use std::path::Path;
 use tar::Archive;
 use tempfile::NamedTempFile;
 use url::Url;
 
-pub(crate) fn handle<W>(
+pub(crate) fn handle(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
-    mut bullet: Print<SubBullet<W>>,
     metadata: &Metadata,
-) -> libcnb::Result<(Print<SubBullet<W>>, LayerEnv), RubyBuildpackError>
-where
-    W: Write + Send + Sync + 'static,
-{
+) -> libcnb::Result<LayerEnv, RubyBuildpackError> {
     let layer_ref = DiffMigrateLayer {
         build: true,
         launch: true,
@@ -71,7 +64,7 @@ where
             _ = timer.done();
         }
     }
-    Ok((bullet, layer_ref.read_env()?))
+    layer_ref.read_env()
 }
 
 fn install_ruby(metadata: &Metadata, layer_path: &Path) -> Result<(), RubyBuildpackError> {

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -184,22 +184,20 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Setup bundler
-        (build_output, env) = {
-            let bullet = build_output.bullet(format!(
+        env = {
+            print::bullet(format!(
                 "Bundler version {} from {}",
                 style::value(bundler_version.to_string()),
                 style::value(gemfile_lock.bundler_source())
             ));
-            let (bullet, layer_env) = layers::bundle_download_layer::handle(
+            let layer_env = layers::bundle_download_layer::handle(
                 &context,
                 &env,
-                bullet,
                 &layers::bundle_download_layer::Metadata {
                     version: bundler_version,
                 },
             )?;
-
-            (bullet.done(), layer_env.apply(Scope::Build, &env))
+            layer_env.apply(Scope::Build, &env)
         };
 
         // ## Bundle install

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -3,8 +3,7 @@
 // to be able selectively opt out of coverage for functions/lines/modules.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
-use bullet_stream::global::print;
-use bullet_stream::{style, Print};
+use bullet_stream::{global::print, style};
 use commons::cache::CacheError;
 use commons::gemfile_lock::GemfileLock;
 use commons::metadata_digest::MetadataDigest;
@@ -121,7 +120,6 @@ impl Buildpack for RubyBuildpack {
     #[allow(clippy::too_many_lines)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let started = print::buildpack("Heroku Ruby Buildpack");
-        let mut build_output = Print::global().h2("Heroku Ruby Buildpack");
 
         // ## Set default environment
         let (mut env, store) =

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -163,7 +163,7 @@ impl Buildpack for RubyBuildpack {
                 style::value(ruby_version.to_string()),
                 style::value(gemfile_lock.ruby_source())
             ));
-            let layer_env = layers::ruby_install_layer::handle(
+            let layer_env = layers::ruby_install_layer::call(
                 &context,
                 &layers::ruby_install_layer::Metadata {
                     os_distribution: OsDistribution {
@@ -184,7 +184,7 @@ impl Buildpack for RubyBuildpack {
                 style::value(bundler_version.to_string()),
                 style::value(gemfile_lock.bundler_source())
             ));
-            let layer_env = layers::bundle_download_layer::handle(
+            let layer_env = layers::bundle_download_layer::call(
                 &context,
                 &env,
                 &layers::bundle_download_layer::Metadata {
@@ -197,7 +197,7 @@ impl Buildpack for RubyBuildpack {
         // ## Bundle install
         env = {
             print::bullet("Bundle install gems");
-            let layer_env = layers::bundle_install_layer::handle(
+            let layer_env = layers::bundle_install_layer::call(
                 &context,
                 &env,
                 &layers::bundle_install_layer::Metadata {

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -3,6 +3,7 @@
 // to be able selectively opt out of coverage for functions/lines/modules.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+use bullet_stream::global::print;
 use bullet_stream::{style, Print};
 use commons::cache::CacheError;
 use commons::gemfile_lock::GemfileLock;
@@ -150,12 +151,11 @@ impl Buildpack for RubyBuildpack {
             if lockfile_contents.contains("barnes") {
                 layers::metrics_agent_install::handle_metrics_agent_layer(&context, bullet)?.done()
             } else {
-                bullet
-                    .sub_bullet(format!(
-                        "Skipping install ({barnes} gem not found)",
-                        barnes = style::value("barnes")
-                    ))
-                    .done()
+                print::sub_bullet(format!(
+                    "Skipping install ({barnes} gem not found)",
+                    barnes = style::value("barnes")
+                ));
+                bullet.done()
             }
         };
 

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -261,15 +261,9 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Detect gems
-        let (gem_list, default_process) = {
-            let bullet = build_output.bullet("Default process detection");
-
-            let (_, gem_list) =
-                gem_list::bundle_list(bullet, &env).map_err(RubyBuildpackError::GemListGetError)?;
-            let default_process = steps::get_default_process(&context, &gem_list);
-
-            (gem_list, default_process)
-        };
+        print::bullet("Default process detection");
+        let gem_list = gem_list::bundle_list(&env).map_err(RubyBuildpackError::GemListGetError)?;
+        let default_process = steps::get_default_process(&context, &gem_list);
 
         // ## Assets install
         print::bullet("Rake assets install");

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -272,11 +272,8 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Assets install
-
         print::bullet("Rake assets install");
-        let (rake_detect) = crate::steps::detect_rake_tasks(&gem_list, &context, &env)?;
-
-        if let Some(rake_detect) = rake_detect {
+        if let Some(rake_detect) = crate::steps::detect_rake_tasks(&gem_list, &context, &env)? {
             crate::steps::rake_assets_install(&context, &env, &rake_detect)?;
         }
         print::all_done(&Some(started));

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -272,21 +272,16 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Assets install
-        _ = {
-            let (bullet, rake_detect) = crate::steps::detect_rake_tasks(
-                build_output.bullet("Rake assets install"),
-                &gem_list,
-                &context,
-                &env,
-            )?;
+        let (bullet, rake_detect) = crate::steps::detect_rake_tasks(
+            build_output.bullet("Rake assets install"),
+            &gem_list,
+            &context,
+            &env,
+        )?;
 
-            if let Some(rake_detect) = rake_detect {
-                crate::steps::rake_assets_install(bullet, &context, &env, &rake_detect)?
-            } else {
-                bullet
-            }
-            .done()
-        };
+        if let Some(rake_detect) = rake_detect {
+            crate::steps::rake_assets_install(bullet, &context, &env, &rake_detect)?;
+        }
         print::all_done(&Some(started));
 
         if let Some(default_process) = default_process {

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -161,15 +161,14 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Install executable ruby version
-        (build_output, env) = {
-            let bullet = build_output.bullet(format!(
+        env = {
+            print::bullet(format!(
                 "Ruby version {} from {}",
                 style::value(ruby_version.to_string()),
                 style::value(gemfile_lock.ruby_source())
             ));
-            let (bullet, layer_env) = layers::ruby_install_layer::handle(
+            let layer_env = layers::ruby_install_layer::handle(
                 &context,
-                bullet,
                 &layers::ruby_install_layer::Metadata {
                     os_distribution: OsDistribution {
                         name: context.target.distro_name.clone(),
@@ -179,8 +178,7 @@ impl Buildpack for RubyBuildpack {
                     ruby_version: ruby_version.clone(),
                 },
             )?;
-
-            (bullet.done(), layer_env.apply(Scope::Build, &env))
+            layer_env.apply(Scope::Build, &env)
         };
 
         // ## Setup bundler

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -120,6 +120,7 @@ impl Buildpack for RubyBuildpack {
 
     #[allow(clippy::too_many_lines)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        let started = print::buildpack("Heroku Ruby Buildpack");
         let mut build_output = Print::global().h2("Heroku Ruby Buildpack");
 
         // ## Set default environment
@@ -271,7 +272,7 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Assets install
-        build_output = {
+        _ = {
             let (bullet, rake_detect) = crate::steps::detect_rake_tasks(
                 build_output.bullet("Rake assets install"),
                 &gem_list,
@@ -286,7 +287,7 @@ impl Buildpack for RubyBuildpack {
             }
             .done()
         };
-        build_output.done();
+        print::all_done(&Some(started));
 
         if let Some(default_process) = default_process {
             BuildResultBuilder::new()

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -261,14 +261,14 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Detect gems
-        let (mut build_output, gem_list, default_process) = {
+        let (gem_list, default_process) = {
             let bullet = build_output.bullet("Default process detection");
 
-            let (bullet, gem_list) =
+            let (_, gem_list) =
                 gem_list::bundle_list(bullet, &env).map_err(RubyBuildpackError::GemListGetError)?;
-            let (bullet, default_process) = steps::get_default_process(bullet, &context, &gem_list);
+            let default_process = steps::get_default_process(&context, &gem_list);
 
-            (bullet.done(), gem_list, default_process)
+            (gem_list, default_process)
         };
 
         // ## Assets install

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -203,12 +203,11 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Bundle install
-        (build_output, env) = {
-            let bullet = build_output.bullet("Bundle install gems");
-            let (bullet, layer_env) = layers::bundle_install_layer::handle(
+        env = {
+            print::bullet("Bundle install gems");
+            let layer_env = layers::bundle_install_layer::handle(
                 &context,
                 &env,
-                bullet,
                 &layers::bundle_install_layer::Metadata {
                     os_distribution: OsDistribution {
                         name: context.target.distro_name.clone(),
@@ -235,7 +234,7 @@ impl Buildpack for RubyBuildpack {
                 &BundleWithout::new("development:test"),
             )?;
 
-            (bullet.done(), layer_env.apply(Scope::Build, &env))
+            layer_env.apply(Scope::Build, &env)
         };
 
         env = {
@@ -256,7 +255,6 @@ impl Buildpack for RubyBuildpack {
                         context.app_dir.join("bin"),
                     ),
             )?;
-
             user_binstubs.read_env()?.apply(Scope::Build, &env)
         };
 

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -272,12 +272,9 @@ impl Buildpack for RubyBuildpack {
         };
 
         // ## Assets install
-        let (bullet, rake_detect) = crate::steps::detect_rake_tasks(
-            build_output.bullet("Rake assets install"),
-            &gem_list,
-            &context,
-            &env,
-        )?;
+
+        print::bullet("Rake assets install");
+        let (rake_detect) = crate::steps::detect_rake_tasks(&gem_list, &context, &env)?;
 
         if let Some(rake_detect) = rake_detect {
             crate::steps::rake_assets_install(&context, &env, &rake_detect)?;

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -280,7 +280,7 @@ impl Buildpack for RubyBuildpack {
         )?;
 
         if let Some(rake_detect) = rake_detect {
-            crate::steps::rake_assets_install(bullet, &context, &env, &rake_detect)?;
+            crate::steps::rake_assets_install(&context, &env, &rake_detect)?;
         }
         print::all_done(&Some(started));
 

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -146,19 +146,17 @@ impl Buildpack for RubyBuildpack {
             // Either "Gemfile.lock" or "default"
             cnb.ruby.runtime.sourced_from = gemfile_lock.ruby_source()
         );
+
         // ## Install metrics agent
-        build_output = {
-            let bullet = build_output.bullet("Metrics agent");
-            if lockfile_contents.contains("barnes") {
-                layers::metrics_agent_install::handle_metrics_agent_layer(&context, bullet)?.done()
-            } else {
-                print::sub_bullet(format!(
-                    "Skipping install ({barnes} gem not found)",
-                    barnes = style::value("barnes")
-                ));
-                bullet.done()
-            }
-        };
+        print::bullet("Metrics agent");
+        if lockfile_contents.contains("barnes") {
+            layers::metrics_agent_install::handle_metrics_agent_layer(&context)?;
+        } else {
+            print::sub_bullet(format!(
+                "Skipping install ({barnes} gem not found)",
+                barnes = style::value("barnes")
+            ));
+        }
 
         // ## Install executable ruby version
         env = {

--- a/buildpacks/ruby/src/rake_task_detect.rs
+++ b/buildpacks/ruby/src/rake_task_detect.rs
@@ -1,8 +1,6 @@
 use bullet_stream::global::print;
-use bullet_stream::{state::SubBullet, Print};
 use core::str::FromStr;
 use fun_run::CmdError;
-use std::io::Write;
 use std::{ffi::OsStr, process::Command};
 
 /// Run `rake -P` and parse output to show what rake tasks an application has
@@ -22,13 +20,8 @@ pub(crate) struct RakeDetect {
 /// # Errors
 ///
 /// Will return `Err` if `bundle exec rake -p` command cannot be invoked by the operating system.
-pub(crate) fn call<W, T, K, V>(
-    mut bullet: Print<SubBullet<W>>,
-    envs: T,
-    error_on_failure: bool,
-) -> Result<(Print<SubBullet<W>>, RakeDetect), CmdError>
+pub(crate) fn call<T, K, V>(envs: T, error_on_failure: bool) -> Result<RakeDetect, CmdError>
 where
-    W: Write + Send + Sync + 'static,
     T: IntoIterator<Item = (K, V)>,
     K: AsRef<OsStr>,
     V: AsRef<OsStr>,
@@ -48,7 +41,7 @@ where
         }
     })?;
 
-    RakeDetect::from_str(&output.stdout_lossy()).map(|rake_detect| (bullet, rake_detect))
+    RakeDetect::from_str(&output.stdout_lossy())
 }
 
 impl RakeDetect {

--- a/buildpacks/ruby/src/rake_task_detect.rs
+++ b/buildpacks/ruby/src/rake_task_detect.rs
@@ -1,3 +1,4 @@
+use bullet_stream::global::print;
 use bullet_stream::{state::SubBullet, Print};
 use core::str::FromStr;
 use fun_run::CmdError;
@@ -35,7 +36,7 @@ where
     let mut cmd = Command::new("rake");
     cmd.args(["-P", "--trace"]).env_clear().envs(envs);
 
-    let output = bullet.time_cmd(cmd).or_else(|error| {
+    let output = print::sub_time_cmd(cmd).or_else(|error| {
         if error_on_failure {
             Err(error)
         } else {

--- a/buildpacks/ruby/src/steps/detect_rake_tasks.rs
+++ b/buildpacks/ruby/src/steps/detect_rake_tasks.rs
@@ -3,22 +3,15 @@ use crate::rake_status::{check_rake_ready, RakeStatus};
 use crate::rake_task_detect::{self, RakeDetect};
 use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
-use bullet_stream::global::print;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::{global::print, style};
 use libcnb::build::BuildContext;
 use libcnb::Env;
-use std::io::Write;
 
-pub(crate) fn detect_rake_tasks<W>(
-    mut bullet: Print<SubBullet<W>>,
+pub(crate) fn detect_rake_tasks(
     gem_list: &GemList,
     context: &BuildContext<RubyBuildpack>,
     env: &Env,
-) -> Result<(Print<SubBullet<W>>, Option<RakeDetect>), RubyBuildpackError>
-where
-    W: Write + Send + Sync + 'static,
-{
+) -> Result<Option<RakeDetect>, RubyBuildpackError> {
     let help = style::important("HELP");
     let rake = style::value("rake");
     let gemfile = style::value("Gemfile");
@@ -67,12 +60,11 @@ where
                 "Detected rake ({rake} gem found, {rakefile} found at {path})",
                 path = style::value(path.to_string_lossy())
             ));
-            let rake_detect;
-            (bullet, rake_detect) = rake_task_detect::call(bullet, env, true)
-                .map_err(RubyBuildpackError::RakeDetectError)?;
+            let rake_detect =
+                rake_task_detect::call(env, true).map_err(RubyBuildpackError::RakeDetectError)?;
 
             Some(rake_detect)
         }
     };
-    Ok((bullet, detect))
+    Ok(detect)
 }

--- a/buildpacks/ruby/src/steps/detect_rake_tasks.rs
+++ b/buildpacks/ruby/src/steps/detect_rake_tasks.rs
@@ -3,6 +3,7 @@ use crate::rake_status::{check_rake_ready, RakeStatus};
 use crate::rake_task_detect::{self, RakeDetect};
 use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
+use bullet_stream::global::print;
 use bullet_stream::state::SubBullet;
 use bullet_stream::{style, Print};
 use libcnb::build::BuildContext;
@@ -10,7 +11,7 @@ use libcnb::Env;
 use std::io::Write;
 
 pub(crate) fn detect_rake_tasks<W>(
-    bullet: Print<SubBullet<W>>,
+    mut bullet: Print<SubBullet<W>>,
     gem_list: &GemList,
     context: &BuildContext<RubyBuildpack>,
     env: &Env,
@@ -23,28 +24,26 @@ where
     let gemfile = style::value("Gemfile");
     let rakefile = style::value("Rakefile");
 
-    match check_rake_ready(
+    let detect = match check_rake_ready(
         &context.app_dir,
         gem_list,
         [".sprockets-manifest-*.json", "manifest-*.json"],
     ) {
-        RakeStatus::MissingRakeGem => Ok((
-            bullet
-                .sub_bullet(format!(
-                    "Skipping rake tasks ({rake} gem not found in {gemfile})"
-                ))
-                .sub_bullet(format!(
-                    "{help} Add {gem} to your {gemfile} to enable",
-                    gem = style::value("gem 'rake'")
-                )),
-            None,
-        )),
-        RakeStatus::MissingRakefile => Ok((
-            bullet
-                .sub_bullet(format!("Skipping rake tasks ({rakefile} not found)",))
-                .sub_bullet(format!("{help} Add {rakefile} to your project to enable",)),
-            None,
-        )),
+        RakeStatus::MissingRakeGem => {
+            print::sub_bullet(format!(
+                "Skipping rake tasks ({rake} gem not found in {gemfile})"
+            ));
+            print::sub_bullet(format!(
+                "{help} Add {gem} to your {gemfile} to enable",
+                gem = style::value("gem 'rake'")
+            ));
+            None
+        }
+        RakeStatus::MissingRakefile => {
+            print::sub_bullet(format!("Skipping rake tasks ({rakefile} not found)",));
+            print::sub_bullet(format!("{help} Add {rakefile} to your project to enable",));
+            None
+        }
         RakeStatus::SkipManifestFound(paths) => {
             let manifest_files = paths
                 .iter()
@@ -52,32 +51,28 @@ where
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            Ok((
-                bullet
-                    .sub_bullet(format!(
-                        "Skipping rake tasks (Manifest {files} found {manifest_files})",
-                        files = if manifest_files.len() > 1 {
-                            "files"
-                        } else {
-                            "file"
-                        }
-                    ))
-                    .sub_bullet(format!("{help} Delete files to enable running rake tasks")),
-                None,
-            ))
+            print::sub_bullet(format!(
+                "Skipping rake tasks (Manifest {files} found {manifest_files})",
+                files = if manifest_files.len() > 1 {
+                    "files"
+                } else {
+                    "file"
+                }
+            ));
+            print::sub_bullet(format!("{help} Delete files to enable running rake tasks"));
+            None
         }
         RakeStatus::Ready(path) => {
-            let (bullet, rake_detect) = rake_task_detect::call(
-                bullet.sub_bullet(format!(
-                    "Detected rake ({rake} gem found, {rakefile} found at {path})",
-                    path = style::value(path.to_string_lossy())
-                )),
-                env,
-                true,
-            )
-            .map_err(RubyBuildpackError::RakeDetectError)?;
+            print::sub_bullet(format!(
+                "Detected rake ({rake} gem found, {rakefile} found at {path})",
+                path = style::value(path.to_string_lossy())
+            ));
+            let rake_detect;
+            (bullet, rake_detect) = rake_task_detect::call(bullet, env, true)
+                .map_err(RubyBuildpackError::RakeDetectError)?;
 
-            Ok((bullet, Some(rake_detect)))
+            Some(rake_detect)
         }
-    }
+    };
+    Ok((bullet, detect))
 }

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -2,12 +2,10 @@ use crate::gem_list::GemList;
 use crate::RubyBuildpack;
 use bullet_stream::global::print;
 use bullet_stream::style;
-use bullet_stream::{state::SubBullet, Print};
 use libcnb::build::BuildContext;
 use libcnb::data::launch::Process;
 use libcnb::data::launch::ProcessBuilder;
 use libcnb::data::process_type;
-use std::io::Write;
 use std::path::Path;
 
 pub(crate) fn get_default_process(

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -1,5 +1,6 @@
 use crate::gem_list::GemList;
 use crate::RubyBuildpack;
+use bullet_stream::global::print;
 use bullet_stream::style;
 use bullet_stream::{state::SubBullet, Print};
 use libcnb::build::BuildContext;
@@ -21,30 +22,31 @@ where
     let rails = style::value("rails");
     let rack = style::value("rack");
     let railties = style::value("railties");
-    match detect_web(gem_list, &context.app_dir) {
-        WebProcess::Rails => (
-            bullet.sub_bullet(format!("Detected rails app ({rails} gem found)")),
-            Some(default_rails()),
-        ),
-        WebProcess::RackWithConfigRU => (
-            bullet.sub_bullet(format!(
+    let process = match detect_web(gem_list, &context.app_dir) {
+        WebProcess::Rails => {
+            print::sub_bullet(format!("Detected rails app ({rails} gem found)"));
+            Some(default_rails())
+        }
+        WebProcess::RackWithConfigRU => {
+            print::sub_bullet(format!(
                 "Detected rack app ({rack} gem found and {config_ru} at root of application)"
-            )),
-            Some(default_rack()),
-        ),
-        WebProcess::RackMissingConfigRu => (
-            bullet.sub_bullet(format!(
+            ));
+            Some(default_rack())
+        }
+        WebProcess::RackMissingConfigRu => {
+            print::sub_bullet(format!(
                 "Skipping default web process ({rack} gem found but missing {config_ru} file)"
-            )),
-            None,
-        ),
-        WebProcess::Missing => (
-            bullet.sub_bullet(format!(
+            ));
+            None
+        }
+        WebProcess::Missing => {
+            print::sub_bullet(format!(
                 "Skipping default web process ({rails}, {railties}, and {rack} not found)"
-            )),
-            None,
-        ),
-    }
+            ));
+            None
+        }
+    };
+    (bullet, process)
 }
 
 enum WebProcess {

--- a/buildpacks/ruby/src/steps/get_default_process.rs
+++ b/buildpacks/ruby/src/steps/get_default_process.rs
@@ -10,19 +10,15 @@ use libcnb::data::process_type;
 use std::io::Write;
 use std::path::Path;
 
-pub(crate) fn get_default_process<W>(
-    bullet: Print<SubBullet<W>>,
+pub(crate) fn get_default_process(
     context: &BuildContext<RubyBuildpack>,
     gem_list: &GemList,
-) -> (Print<SubBullet<W>>, Option<Process>)
-where
-    W: Write + Send + Sync + 'static,
-{
+) -> Option<Process> {
     let config_ru = style::value("config.ru");
     let rails = style::value("rails");
     let rack = style::value("rack");
     let railties = style::value("railties");
-    let process = match detect_web(gem_list, &context.app_dir) {
+    match detect_web(gem_list, &context.app_dir) {
         WebProcess::Rails => {
             print::sub_bullet(format!("Detected rails app ({rails} gem found)"));
             Some(default_rails())
@@ -45,8 +41,7 @@ where
             ));
             None
         }
-    };
-    (bullet, process)
+    }
 }
 
 enum WebProcess {

--- a/buildpacks/ruby/src/steps/rake_assets_install.rs
+++ b/buildpacks/ruby/src/steps/rake_assets_install.rs
@@ -1,24 +1,17 @@
 use crate::rake_task_detect::RakeDetect;
 use crate::RubyBuildpack;
 use crate::RubyBuildpackError;
-use bullet_stream::global::print;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::{global::print, style};
 use commons::cache::{mib, AppCache, CacheConfig, CacheError, CacheState, KeepPath, PathState};
 use libcnb::build::BuildContext;
 use libcnb::Env;
-use std::io::Write;
 use std::process::Command;
 
-pub(crate) fn rake_assets_install<W>(
-    mut bullet: Print<SubBullet<W>>,
+pub(crate) fn rake_assets_install(
     context: &BuildContext<RubyBuildpack>,
     env: &Env,
     rake_detect: &RakeDetect,
-) -> Result<Print<SubBullet<W>>, RubyBuildpackError>
-where
-    W: Write + Send + Sync + 'static,
-{
+) -> Result<(), RubyBuildpackError> {
     let help = style::important("HELP");
     let cases = asset_cases(rake_detect);
     let rake_assets_precompile = style::value("rake assets:precompile");
@@ -117,7 +110,7 @@ where
         }
     }
 
-    Ok(bullet)
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/buildpacks/ruby/src/steps/rake_assets_install.rs
+++ b/buildpacks/ruby/src/steps/rake_assets_install.rs
@@ -43,8 +43,7 @@ where
                 .env_clear()
                 .envs(env);
 
-            bullet
-                .stream_cmd(&mut cmd)
+            print::sub_stream_cmd(&mut cmd)
                 .map_err(|error| {
                     fun_run::map_which_problem(error, &mut cmd, env.get("PATH").cloned())
                 })
@@ -86,8 +85,7 @@ where
                 .env_clear()
                 .envs(env);
 
-            bullet
-                .stream_cmd(&mut cmd)
+            print::sub_stream_cmd(&mut cmd)
                 .map_err(|error| {
                     fun_run::map_which_problem(error, &mut cmd, env.get("PATH").cloned())
                 })

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -54,7 +54,7 @@ fn log_our_error(error: RubyBuildpackError) {
             print::error(formatdoc! {"
                 Error: `Gemfile` found with error
 
-                There was an error trying to read the contents of the application's Gemfile. \
+                There was an error trying to read the contents of the application's Gemfile.
                 The buildpack cannot continue if the Gemfile is unreadable.
 
                 {error}
@@ -66,15 +66,15 @@ fn log_our_error(error: RubyBuildpackError) {
             print::error(formatdoc! {"
                 Error: `package.json` found with error
 
-                The Ruby buildpack detected a package.json file but it is not readable \
+                The Ruby buildpack detected a package.json file but it is not readable
                 due to the following errors:
 
                 {error}
 
-                If your application does not need any node dependencies installed, \
+                If your application does not need any node dependencies installed,
                 you may delete this file and try again.
 
-                If you are expecting node dependencies to be installed, please \
+                If you are expecting node dependencies to be installed, please
                 debug using the above information and try again.
             "});
         }
@@ -82,7 +82,7 @@ fn log_our_error(error: RubyBuildpackError) {
             print::error(formatdoc! {"
                 Error: `Gemfile.lock` found with error
 
-                There was an error trying to read the contents of the application's Gemfile.lock. \
+                There was an error trying to read the contents of the application's Gemfile.lock.
                 The buildpack cannot continue if the Gemfile is unreadable.
 
                 {error}
@@ -94,15 +94,15 @@ fn log_our_error(error: RubyBuildpackError) {
             print::error(formatdoc! {"
                 Error: `yarn.lock` found with error
 
-                The Ruby buildpack detected a yarn.lock file but it is not readable \
+                The Ruby buildpack detected a yarn.lock file but it is not readable
                 due to the following errors:
 
                 {error}
 
-                If your application does not need yarn installed, you \
+                If your application does not need yarn installed, you
                 may delete this file and try again.
 
-                If you are expecting yarn to be installed, please \
+                If you are expecting yarn to be installed, please
                 debug using the above information and try again.
             "});
         }

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -1,53 +1,47 @@
 use crate::{DetectError, RubyBuildpackError};
-use bullet_stream::{state::Bullet, state::SubBullet, style, Print};
+use bullet_stream::{global::print, style};
 use fun_run::CmdError;
 use indoc::formatdoc;
-use std::io::Write;
 use std::process::Command;
 const DEBUG_INFO_STR: &str = "Debug info";
 
 pub(crate) fn on_error(err: libcnb::Error<RubyBuildpackError>) {
-    let output = Print::global().without_header();
     let debug_info = style::important(DEBUG_INFO_STR);
     match cause(err) {
-        Cause::OurError(error) => log_our_error(output, error),
+        Cause::OurError(error) => log_our_error(error),
         Cause::FrameworkError(error) => {
-            output
-                .bullet(&debug_info)
-                .sub_bullet(error.to_string())
-                .error(formatdoc! {"
-                    Error: heroku/buildpack-ruby internal buildpack error
+            print::bullet(&debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
+                Error: heroku/buildpack-ruby internal buildpack error
 
-                    The framework used by this buildpack encountered an unexpected error.
-                    This type of error usually indicates there's nothing wrong with your application.
+                The framework used by this buildpack encountered an unexpected error.
+                This type of error usually indicates there's nothing wrong with your application.
 
-                    If you can’t deploy to Heroku due to this issue please check the official Heroku
-                    status page https://status.heroku.com/ to see if there is an ongoing incident. Once
-                    all incidents have resolved please retry your build.
+                If you can’t deploy to Heroku due to this issue please check the official Heroku
+                status page https://status.heroku.com/ to see if there is an ongoing incident. Once
+                all incidents have resolved please retry your build.
 
-                    If the issue persists, try to reproduce the behavior locally using the `pack` CLI.
-                    If you can reproduce the behavior locally and believe you've found a bug in the
-                    buildpack or framework, please visit the buildpack's GitHub repository at
-                    https://github.com/heroku/buildpacks-ruby/issues. Search for any existing issues
-                    related to this error. If none are found, please consider opening a new issue.
+                If the issue persists, try to reproduce the behavior locally using the `pack` CLI.
+                If you can reproduce the behavior locally and believe you've found a bug in the
+                buildpack or framework, please visit the buildpack's GitHub repository at
+                https://github.com/heroku/buildpacks-ruby/issues. Search for any existing issues
+                related to this error. If none are found, please consider opening a new issue.
 
-                    For more details on expected behavior, see the application contract at
-                    https://github.com/heroku/buildpacks-ruby/blob/main/docs/application_contract.md
-                    If you notice a difference between the contract and actual buildpack behavior,
-                    please open an issue with a minimal application to reproduce the problem.
+                For more details on expected behavior, see the application contract at
+                https://github.com/heroku/buildpacks-ruby/blob/main/docs/application_contract.md
+                If you notice a difference between the contract and actual buildpack behavior,
+                please open an issue with a minimal application to reproduce the problem.
 
-                    For application-specific support, consider asking on official Heroku support
-                    channels or Stack Overflow.
-                "});
+                For application-specific support, consider asking on official Heroku support
+                channels or Stack Overflow.
+            "});
         }
     }
 }
 
 #[allow(clippy::too_many_lines)]
-fn log_our_error<W: Write + Send + Sync + 'static>(
-    mut output: Print<Bullet<W>>,
-    error: RubyBuildpackError,
-) {
+fn log_our_error(error: RubyBuildpackError) {
     let git_branch_url =
         style::url("https://devcenter.heroku.com/articles/git#deploy-from-a-branch-besides-main");
     let ruby_versions_url =
@@ -57,7 +51,7 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
 
     match error {
         RubyBuildpackError::BuildpackDetectionError(DetectError::Gemfile(error)) => {
-            output.error(formatdoc! {"
+            print::error(formatdoc! {"
                 Error: `Gemfile` found with error
 
                 There was an error trying to read the contents of the application's Gemfile. \
@@ -69,7 +63,7 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             "});
         }
         RubyBuildpackError::BuildpackDetectionError(DetectError::PackageJson(error)) => {
-            output.error(formatdoc! {"
+            print::error(formatdoc! {"
                 Error: `package.json` found with error
 
                 The Ruby buildpack detected a package.json file but it is not readable \
@@ -85,7 +79,7 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             "});
         }
         RubyBuildpackError::BuildpackDetectionError(DetectError::GemfileLock(error)) => {
-            output.error(formatdoc! {"
+            print::error(formatdoc! {"
                 Error: `Gemfile.lock` found with error
 
                 There was an error trying to read the contents of the application's Gemfile.lock. \
@@ -97,7 +91,7 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             "});
         }
         RubyBuildpackError::BuildpackDetectionError(DetectError::YarnLock(error)) => {
-            output.error(formatdoc! {"
+            print::error(formatdoc! {"
                 Error: `yarn.lock` found with error
 
                 The Ruby buildpack detected a yarn.lock file but it is not readable \
@@ -113,25 +107,21 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             "});
         }
         RubyBuildpackError::MissingGemfileLock(path, error) => {
-            output = output
-                .bullet(format!(
-                    "Could not find {}, details:",
-                    style::value(path.to_string_lossy())
-                ))
-                .sub_bullet(error.to_string())
-                .done();
+            print::bullet(format!(
+                "Could not find {}, details:",
+                style::value(path.to_string_lossy())
+            ));
+            print::sub_bullet(error.to_string());
 
             if let Some(dir) = path.parent() {
-                output = debug_cmd(
-                    output.bullet(format!(
-                        "{debug_info} Contents of the {} directory",
-                        style::value(dir.to_string_lossy())
-                    )),
-                    Command::new("ls").args(["la", &dir.to_string_lossy()]),
-                );
+                print::bullet(format!(
+                    "{debug_info} Contents of the {dir} directory",
+                    dir = style::value(dir.to_string_lossy())
+                ));
+                let _ =
+                    print::sub_stream_cmd(Command::new("ls").args(["-la", &dir.to_string_lossy()]));
             }
-
-            output.error(formatdoc! {"
+            print::error(formatdoc! {"
                 Error: `Gemfile.lock` not found
 
                 A `Gemfile.lock` file is required and was not found in the root of your application.
@@ -147,9 +137,9 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             // Future:
             // - In the future use a manifest file to list if version is available on a different stack
             // - In the future add a "did you mean" Levenshtein distance to see if they typoed like "3.6.0" when they meant "3.0.6"
-            output.bullet(debug_info)
-                .sub_bullet(error.to_string())
-                .error(formatdoc! {"
+            print::bullet(debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
                     Error installing Ruby
 
                     Could not install the detected Ruby version. Ensure that you're using a supported
@@ -160,14 +150,9 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
                 "});
         }
         RubyBuildpackError::GemInstallBundlerCommandError(error) => {
-            output = output
-                .bullet(&debug_info)
-                .sub_bullet(error.to_string())
-                .done();
-
-            output = debug_cmd(output.bullet(&debug_info), Command::new("gem").arg("env"));
-
-            output.error(formatdoc! {"
+            print::bullet(debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
                 Error installing bundler
 
                 The ruby package managment tool, `bundler`, failed to install. Bundler is required
@@ -183,11 +168,9 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             // Future:
             // - Grep error output for common things like using sqlite3, use classic buildpack
             let local_command = local_command_debug(&error);
-            output
-                .bullet(&debug_info)
-                .sub_bullet(error.to_string())
-                .done()
-                .error(formatdoc! {"
+            print::bullet(debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
                     Error installing your applications's dependencies
 
                     Could not install gems to the system via bundler. Gems are dependencies
@@ -203,22 +186,18 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
                 "});
         }
         RubyBuildpackError::BundleInstallDigestError(path, error) => {
-            output = output
-                .bullet(&debug_info)
-                .sub_bullet(error.to_string())
-                .done();
+            print::bullet(&debug_info);
+            print::sub_bullet(error.to_string());
 
             if let Some(dir) = path.parent() {
-                output = debug_cmd(
-                    output.bullet(format!(
-                        "{debug_info} Contents of the {} directory",
-                        style::value(dir.to_string_lossy())
-                    )),
-                    Command::new("ls").args(["la", &dir.to_string_lossy()]),
-                );
+                print::bullet(format!(
+                    "{debug_info} Contents of the {} directory",
+                    style::value(dir.to_string_lossy())
+                ));
+                let _ =
+                    print::sub_stream_cmd(Command::new("ls").args(["-la", &dir.to_string_lossy()]));
             }
-
-            output.error(formatdoc! {"
+            print::error(formatdoc! {"
                 Error generating file digest
 
                 An error occurred while generating a file digest. To provide the fastest possible
@@ -238,11 +217,9 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             // Future:
             // - Annotate with information on requiring test or development only gems in the Rakefile
             let local_command = local_command_debug(&error);
-            output
-                .bullet(debug_info)
-                .sub_bullet(error.to_string())
-                .done()
-                .error(formatdoc! {"
+            print::bullet(debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
                     Error detecting rake tasks
 
                     The Ruby buildpack uses rake task information from your application to guide
@@ -255,51 +232,46 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
         }
         RubyBuildpackError::RakeAssetsPrecompileFailed(error) => {
             let local_command = local_command_debug(&error);
-            output
-                .bullet(debug_info)
-                .sub_bullet(error.to_string())
-                .done()
-                .error(formatdoc! {"
-                    Error compiling assets
+            print::bullet(debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
+                Error compiling assets
 
-                    An error occured while compiling assets via rake command.
+                An error occured while compiling assets via rake command.
 
-                    {local_command}
+                {local_command}
 
-                    Use the information above to debug further.
-                "});
+                Use the information above to debug further.
+            "});
         }
         RubyBuildpackError::InAppDirCacheError(error) => {
             // Future:
             // - Separate between failures in layer dirs or in app dirs, if we can isolate to an app dir we could debug more
             // to determine if there's bad permissions or bad file symlink
-            output
-                .bullet(debug_info)
-                .sub_bullet(error.to_string())
-                .done()
-                .error(formatdoc! {"
-                    Error caching frontend assets
+            print::bullet(debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
+                Error caching frontend assets
 
-                    An error occurred while attempting to cache frontend assets, and the Ruby buildpack
-                    cannot continue.
+                An error occurred while attempting to cache frontend assets, and the Ruby buildpack
+                cannot continue.
 
-                    Ensure that the permissions on the files in your application directory are correct and that
-                    all symlinks correctly resolve.
-                "});
+                Ensure that the permissions on the files in your application directory are correct and that
+                all symlinks correctly resolve.
+            "});
         }
         RubyBuildpackError::GemListGetError(error) => {
-            output = output
-                .bullet(&debug_info)
-                .sub_bullet(error.to_string())
-                .done();
+            match &error {
+                CmdError::SystemError(_, _) => {}
+                CmdError::NonZeroExitNotStreamed(_) | CmdError::NonZeroExitAlreadyStreamed(_) => {
+                    print::bullet(&debug_info);
+                    let _ = print::sub_stream_cmd(Command::new("gem").arg("env"));
 
-            output = debug_cmd(output.bullet(&debug_info), Command::new("gem").arg("env"));
-            output = debug_cmd(
-                output.bullet(&debug_info),
-                Command::new("bundle").arg("env"),
-            );
-
-            output.error(formatdoc! {"
+                    print::bullet(&debug_info);
+                    let _ = print::sub_stream_cmd(Command::new("bundle").arg("env"));
+                }
+            }
+            print::error(formatdoc! {"
                 Error detecting dependencies
 
                 The Ruby buildpack requires information about your application’s dependencies to
@@ -309,16 +281,14 @@ fn log_our_error<W: Write + Send + Sync + 'static>(
             "});
         }
         RubyBuildpackError::MetricsAgentError(error) => {
-            output
-                .bullet(debug_info)
-                .sub_bullet(error.to_string())
-                .done()
-                .error(formatdoc! {"
-                    Error: Could not install Statsd agent
+            print::bullet(&debug_info);
+            print::sub_bullet(error.to_string());
+            print::error(formatdoc! {"
+                Error: Could not install Statsd agent
 
-                    An error occured while downloading and installing the metrics agent
-                    the buildpack cannot continue.
-                "});
+                An error occured while downloading and installing the metrics agent
+                the buildpack cannot continue.
+            "});
         }
     }
 }
@@ -351,16 +321,6 @@ fn replace_app_path_with_relative(contents: impl AsRef<str>) -> String {
     let app_path_re = regex::Regex::new("/workspace/").expect("Internal error: regex");
 
     app_path_re.replace_all(contents.as_ref(), "./").to_string()
-}
-
-fn debug_cmd<W: Write + Send + Sync + 'static>(
-    mut log: Print<SubBullet<W>>,
-    command: &mut Command,
-) -> Print<Bullet<W>> {
-    match log.stream_cmd(command) {
-        Ok(_) => log.done(),
-        Err(e) => log.sub_bullet(e.to_string()).done(),
-    }
 }
 
 #[cfg(test)]

--- a/commons/src/layer/fixtures/metadata_migration_example.md
+++ b/commons/src/layer/fixtures/metadata_migration_example.md
@@ -42,8 +42,6 @@ At this point we've implemented `CacheDiff` and `TryMigrate` on our metadata, so
 ```rust
 use commons::layer::diff_migrate::{DiffMigrateLayer, Meta};
 
-use bullet_stream::{Print, state::SubBullet};
-
 use libcnb::layer::{LayerState, EmptyLayerCause};
 use libcnb::data::layer_name;
 use libcnb::Buildpack;


### PR DESCRIPTION
The `bullet_stream` global function interface was introduced in 0.4.0 https://github.com/heroku-buildpacks/bullet_stream/blob/ce8fd41c8886a8f0e2c5992f2bfa673838ad509a/CHANGELOG.md#v040---20250121 

This PR updates the Ruby buildpack to use the new style of printing interface over the heavier type-state interface.

A little history on why it took so long to introduce and adopt a function interface in a functional language:

The original design of the printing interface was a little bit functional with a light type-state pattern. You can see the original interface here https://github.com/heroku/buildpacks-ruby/pull/155. 

Over many pairing sessions, the type-state design was emphasized and functional style interfaces de-emphasized. It's a good pattern, but in hind-site not a good fit for the work. 

This work happened in:

- https://github.com/heroku/buildpacks-ruby/pull/175
- https://github.com/heroku/buildpacks-ruby/pull/198

After this point, there were now two interfaces:

- A type-state design that was extremely "safe" but also extremely cumbersome to use
- A functional style interface that was meant to be used with the now-deprecated Layer trait interface for interacting with layers. (https://github.com/heroku/buildpacks-ruby/blob/b3ccd764fc57504eef023859e3405ae99d726f39/commons/src/output/section_log.rs)

We continued working on it, and in an attempt to get it into libcnb, this functional interface was removed to reduce the size of the PR that shipped: https://github.com/heroku/libcnb.rs/pull/721/commits/174fc02af40d1819837a9afe595955a21605364d.

While the PR was technically merged into libcnb, it missed core functionality and was unusable. I ported the code over to a new repo, `heroku-buildpacks/bullet_stream,` with only the type-state API, believing Manuel (who is a co-author of that commit) preferred it. 

I started sending PRs to other repos and got tired of the heavy interface with relatively minimal benefit, and released 0.4.0 with the functional interface. Since then, it's been shown to be a clear favorite for other buildpack maintainers who have chosen to use that library.