### PR TITLE
Remove heroku-20 support

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal API used for producing buildpack output updated. ([#419](https://github.com/heroku/buildpacks-ruby/pull/419))
 
+### Changed
+
+- Removed support for Ubuntu 20.04 (and thus Heroku-20 / `heroku/builder:20`). ([#422](https://github.com/heroku/buildpacks-ruby/pull/422))
+
 ## [7.0.1] - 2025-04-09
 
 ### Added

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -333,7 +333,7 @@ mod test {
             ruby_version: ResolvedRubyVersion("3.5.3".to_string()),
             os_distribution: OsDistribution {
                 name: "ubuntu".to_string(),
-                version: "20.04".to_string(),
+                version: "24.04".to_string(),
             },
             cpu_architecture: "amd64".to_string(),
             force_bundle_install_key: FORCE_BUNDLE_INSTALL_CACHE_KEY.to_string(),
@@ -373,7 +373,7 @@ mod test {
 
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
-            vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
+            vec!["OS Distribution (`ubuntu 24.04` to `alpine 3.20.0`)".to_string()]
         );
 
         let diff = Metadata {
@@ -504,7 +504,7 @@ platform_env = "c571543beaded525b7ee46ceb0b42c0fb7b9f6bfc3a211b3bbcfe6956b69ace3
             ruby_version: ResolvedRubyVersion("3.5.3".to_string()),
             os_distribution: OsDistribution {
                 name: "ubuntu".to_string(),
-                version: "20.04".to_string(),
+                version: "24.04".to_string(),
             },
             cpu_architecture: "amd64".to_string(),
             force_bundle_install_key: "v1".to_string(),

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -325,7 +325,7 @@ version = "3.1.3"
             ruby_version: ResolvedRubyVersion("3.5.3".to_string()),
             os_distribution: OsDistribution {
                 name: "ubuntu".to_string(),
-                version: "20.04".to_string(),
+                version: "24.04".to_string(),
             },
             cpu_architecture: "amd64".to_string(),
         };
@@ -335,7 +335,7 @@ version = "3.1.3"
             ruby_version: ResolvedRubyVersion("3.5.5".to_string()),
             os_distribution: OsDistribution {
                 name: "ubuntu".to_string(),
-                version: "20.04".to_string(),
+                version: "24.04".to_string(),
             },
             cpu_architecture: old.cpu_architecture.clone(),
         }
@@ -358,7 +358,7 @@ version = "3.1.3"
 
         assert_eq!(
             diff.iter().map(strip_ansi).collect::<Vec<String>>(),
-            vec!["OS Distribution (`ubuntu 20.04` to `alpine 3.20.0`)".to_string()]
+            vec!["OS Distribution (`ubuntu 24.04` to `alpine 3.20.0`)".to_string()]
         );
 
         let diff = Metadata {
@@ -385,7 +385,7 @@ version = "3.1.3"
             ruby_version: ResolvedRubyVersion("2.7.2".to_string()),
             os_distribution: OsDistribution {
                 name: "ubuntu".to_string(),
-                version: "20.04".to_string(),
+                version: "24.04".to_string(),
             },
             cpu_architecture: "x86_64".to_string(),
         };

--- a/buildpacks/ruby/src/target_id.rs
+++ b/buildpacks/ruby/src/target_id.rs
@@ -9,7 +9,6 @@ pub(crate) struct TargetId {
 }
 const ARCH_AWARE_VERSIONS: &[&str] = &["24.04"];
 const DISTRO_VERSION_STACK: &[(&str, &str, &str)] = &[
-    ("ubuntu", "20.04", "heroku-20"),
     ("ubuntu", "22.04", "heroku-22"),
     ("ubuntu", "24.04", "heroku-24"),
 ];
@@ -80,17 +79,6 @@ mod test {
     #[test]
     fn test_stack_name() {
         assert_eq!(
-            String::from("heroku-20"),
-            TargetId {
-                cpu_architecture: String::from("amd64"),
-                distro_name: String::from("ubuntu"),
-                distro_version: String::from("20.04"),
-            }
-            .stack_name()
-            .unwrap()
-        );
-
-        assert_eq!(
             String::from("heroku-22"),
             TargetId {
                 cpu_architecture: String::from("amd64"),
@@ -100,25 +88,36 @@ mod test {
             .stack_name()
             .unwrap()
         );
+
+        assert_eq!(
+            String::from("heroku-24"),
+            TargetId {
+                cpu_architecture: String::from("amd64"),
+                distro_name: String::from("ubuntu"),
+                distro_version: String::from("24.04"),
+            }
+            .stack_name()
+            .unwrap()
+        );
     }
 
     #[test]
     fn test_from_stack() {
-        assert_eq!(
-            TargetId::from_stack("heroku-20").unwrap(),
-            TargetId {
-                cpu_architecture: String::from("amd64"),
-                distro_name: String::from("ubuntu"),
-                distro_version: String::from("20.04"),
-            }
-        );
-
         assert_eq!(
             TargetId::from_stack("heroku-22").unwrap(),
             TargetId {
                 cpu_architecture: String::from("amd64"),
                 distro_name: String::from("ubuntu"),
                 distro_version: String::from("22.04"),
+            }
+        );
+
+        assert_eq!(
+            TargetId::from_stack("heroku-24").unwrap(),
+            TargetId {
+                cpu_architecture: String::from("amd64"),
+                distro_name: String::from("ubuntu"),
+                distro_version: String::from("24.04"),
             }
         );
     }

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -85,8 +85,26 @@ fn test_migrating_metadata_or_layer_names() {
 
 #[test]
 #[ignore = "integration test"]
+fn test_default_app_ubuntu22() {
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "tests/fixtures/default_ruby"),
+        |context| {
+            println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
+            assert_contains!(
+                context.pack_stderr,
+                r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
+            );
+
+            assert_contains!(context.pack_stderr, "Installing puma");
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
 #[allow(clippy::too_many_lines)]
-fn test_default_app_ubuntu20() {
+fn test_default_app_ubuntu24() {
     let temp = tempfile::tempdir().unwrap();
     let app_dir = temp.path();
 
@@ -98,7 +116,7 @@ fn test_default_app_ubuntu20() {
         app_dir,
     )
     .unwrap();
-    let config = BuildConfig::new("heroku/builder:20", app_dir);
+    let config = BuildConfig::new("heroku/builder:24", app_dir);
     TestRunner::default().build(
         config.clone(),
         |context| {
@@ -144,12 +162,8 @@ fn test_default_app_ubuntu20() {
                 + which -a rake
                 /layers/heroku_ruby/gems/bin/rake
                 /layers/heroku_ruby/binruby/bin/rake
-                /usr/bin/rake
-                /bin/rake
                 + which -a ruby
                 /layers/heroku_ruby/binruby/bin/ruby
-                /usr/bin/ruby
-                /bin/ruby
             "},
             command_output.stdout,
         );
@@ -222,13 +236,9 @@ fn test_default_app_ubuntu20() {
       /layers/heroku_ruby/gems/bin/rake
       /workspace/bin/rake
       /layers/heroku_ruby/binruby/bin/rake
-      /usr/bin/rake
-      /bin/rake
       $ which -a ruby
       /layers/heroku_ruby/binruby/bin/ruby
-      /usr/bin/ruby
-      /bin/ruby
-            ".trim(),
+           ".trim(),
         rake_output.trim()
 );
 
@@ -246,30 +256,10 @@ fn test_default_app_ubuntu20() {
                     /workspace/bin/rake
                     /layers/heroku_ruby/gems/bin/rake
                     /layers/heroku_ruby/binruby/bin/rake
-                    /usr/bin/rake
-                    /bin/rake
                 "},
                 command_output.stdout,
             );
         });
-        },
-    );
-}
-
-#[test]
-#[ignore = "integration test"]
-fn test_default_app_ubuntu22() {
-    TestRunner::default().build(
-        BuildConfig::new("heroku/builder:22", "tests/fixtures/default_ruby"),
-        |context| {
-            println!("{}", context.pack_stderr);
-            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
-            assert_contains!(
-                context.pack_stderr,
-                r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
-            );
-
-            assert_contains!(context.pack_stderr, "Installing puma");
         },
     );
 }


### PR DESCRIPTION
Since Heroku-20 is has reached end-of-life:
https://devcenter.heroku.com/changelog-items/3230

(When this is released, I'll edit the cnb-builder-images PR by hand so it only updates the newer builders, until such time as more CNBs drop support, then we can adjust the builders list used by the release automation to no longer update the manifest for heroku/builder:20)

- Removed:

  - [x] "20.04"
  - [x] "heroku-20"
  - [x] "builder:20"