### PR TITLE
Run `bundle install` on every push

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `bundle install` command now runs on every deploy, the `HEROKU_SKIP_BUNDLE_DIGEST` environment variable has no effect. ([#425](https://github.com/heroku/buildpacks-ruby/pull/425))
+
 ## [8.0.0] - 2025-05-05
 
 ### Fixed

--- a/buildpacks/ruby/src/layers/bundle_download_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_download_layer.rs
@@ -20,6 +20,9 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Command;
 
+// Latest metadata used for `TryMigrate` trait
+pub(crate) type Metadata = MetadataV1;
+
 pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
@@ -66,8 +69,6 @@ pub(crate) fn call(
     }
     layer_ref.read_env()
 }
-
-pub(crate) type Metadata = MetadataV1;
 
 #[derive(Deserialize, Serialize, Debug, Clone, CacheDiff, TryMigrate)]
 #[try_migrate(from = None)]

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -272,16 +272,6 @@ mod test {
     /// When the vec is empty the cache is kept, otherwise it is invalidated
     #[test]
     fn metadata_diff_messages() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let app_path = tmpdir.path().to_path_buf();
-        let gemfile = app_path.join("Gemfile");
-        let env = Env::new();
-        let context = FakeContext {
-            platform: FakePlatform { env },
-            app_path,
-        };
-        std::fs::write(&gemfile, "iamagemfile").unwrap();
-
         let old = Metadata {
             ruby_version: ResolvedRubyVersion("3.5.3".to_string()),
             os_distribution: OsDistribution {
@@ -385,18 +375,8 @@ GEM_PATH=layer_path
     /// to the current format.
     #[test]
     fn metadata_guard() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let app_path = tmpdir.path().to_path_buf();
-        let gemfile = app_path.join("Gemfile");
-
         let mut env = Env::new();
         env.insert("SECRET_KEY_BASE", "abcdgoldfish");
-
-        let context = FakeContext {
-            platform: FakePlatform { env },
-            app_path,
-        };
-        std::fs::write(&gemfile, "iamagemfile").unwrap();
 
         let target_id = TargetId::from_stack("heroku-22").unwrap();
         let metadata = Metadata {

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -31,11 +31,6 @@ use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Command};
 
-/// A failsafe, if a programmer made a mistake in the caching logic, rev-ing this
-/// key will force a re-run of `bundle install` to ensure the cache is correct
-/// on the next build.
-pub(crate) const FORCE_BUNDLE_INSTALL_CACHE_KEY: &str = "v2";
-
 pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -16,12 +16,10 @@
 //! we must clear the cache and re-run `bundle install`.
 use crate::target_id::{OsDistribution, TargetId, TargetIdError};
 use crate::{BundleWithout, RubyBuildpack, RubyBuildpackError};
-use bullet_stream::{global::print, style};
+use bullet_stream::global::print;
 use cache_diff::CacheDiff;
-use commons::layer::diff_migrate::{DiffMigrateLayer, Meta};
-use commons::{
-    display::SentenceList, gemfile_lock::ResolvedRubyVersion, metadata_digest::MetadataDigest,
-};
+use commons::layer::diff_migrate::DiffMigrateLayer;
+use commons::{gemfile_lock::ResolvedRubyVersion, metadata_digest::MetadataDigest};
 use fun_run::{self, CommandWithName};
 use libcnb::data::layer_name;
 use libcnb::layer::{EmptyLayerCause, LayerState};

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -14,7 +14,7 @@
 //! must be compiled and will then be invoked via FFI. These native extensions are
 //! OS, Architecture, and Ruby version dependent. Due to this, when one of these changes
 //! we must clear the cache and re-run `bundle install`.
-use crate::target_id::{OsDistribution, TargetId, TargetIdError};
+use crate::target_id::OsDistribution;
 use crate::{BundleWithout, RubyBuildpack, RubyBuildpackError};
 use bullet_stream::global::print;
 use cache_diff::CacheDiff;
@@ -186,6 +186,8 @@ fn display_name(cmd: &mut Command, env: &Env) -> String {
 
 #[cfg(test)]
 mod test {
+    use crate::target_id::TargetId;
+
     use super::*;
     use bullet_stream::strip_ansi;
     use commons::display::SentenceList;

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -126,7 +126,8 @@ pub(crate) struct MetadataV3 {
     pub(crate) digest: toml::Value, // Must be last for serde to be happy https://github.com/toml-rs/toml-rs/issues/142
 }
 
-/// Introduced to drop support for MetadataDigest
+// Introduced to drop support for MetadataDigest
+// 2025-05-16
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, CacheDiff, TryMigrate)]
 #[try_migrate(from = MetadataV3)]
 #[serde(deny_unknown_fields)]

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -180,8 +180,6 @@ fn display_name(cmd: &mut Command, env: &Env) -> String {
 
 #[cfg(test)]
 mod test {
-    use crate::target_id::TargetId;
-
     use super::*;
     use bullet_stream::strip_ansi;
     use commons::display::SentenceList;
@@ -272,13 +270,12 @@ GEM_PATH=layer_path
     /// to the current format.
     #[test]
     fn metadata_guard() {
-        let target_id = TargetId::from_stack("heroku-22").unwrap();
         let metadata = Metadata {
             os_distribution: OsDistribution {
-                name: target_id.distro_name.clone(),
-                version: target_id.distro_version.clone(),
+                name: "ubuntu".to_string(),
+                version: "22.04".to_string(),
             },
-            cpu_architecture: target_id.cpu_architecture,
+            cpu_architecture: "amd64".to_string(),
             ruby_version: ResolvedRubyVersion(String::from("3.1.3")),
         };
 
@@ -302,7 +299,6 @@ version = "22.04"
 
     #[test]
     fn metadata_migrate_v1_to_v2() {
-        let target_id = TargetId::from_stack("heroku-24").unwrap();
         let metadata = MetadataV3 {
             ruby_version: ResolvedRubyVersion(String::from("3.1.3")),
             force_bundle_install_key: String::from("v1"),
@@ -315,8 +311,8 @@ version = "22.04"
             )
             .unwrap(),
             os_distribution: OsDistribution {
-                name: target_id.distro_name,
-                version: target_id.distro_version
+                name: "ubuntu".to_string(),
+                version: "24.04".to_string()
             },
             cpu_architecture: "arm64".to_string(),
         };

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -53,23 +53,18 @@ pub(crate) fn call(
         launch: true,
     }
     .cached_layer(layer_name!("gems"), context, metadata)?;
-    let _ = match &layer_ref.state {
+    match &layer_ref.state {
         LayerState::Restored { cause } => {
             print::sub_bullet(cause);
-            match cause {
-                Meta::Data(old) => install_state(old, metadata),
-                Meta::Message(_) => InstallState::Run(String::new()),
-            }
         }
         LayerState::Empty { cause } => match cause {
-            EmptyLayerCause::NewlyCreated => InstallState::Run(String::new()),
+            EmptyLayerCause::NewlyCreated => (),
             EmptyLayerCause::InvalidMetadataAction { cause }
             | EmptyLayerCause::RestoredLayerAction { cause } => {
                 print::sub_bullet(cause);
-                InstallState::Run(String::new())
             }
         },
-    };
+    }
 
     let env = {
         let layer_env = layer_env(&layer_ref.path(), &context.app_dir, without);

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -107,6 +107,8 @@ pub(crate) struct MetadataV2 {
     pub(crate) digest: toml::Value, // Must be last for serde to be happy https://github.com/toml-rs/toml-rs/issues/142
 }
 
+// Introduced in https://github.com/heroku/buildpacks-ruby/pull/370
+// 2024-12-13
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, CacheDiff, TryMigrate)]
 #[cache_diff(custom = clear_v1)]
 #[try_migrate(from = MetadataV2)]

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -278,9 +278,6 @@ GEM_PATH=layer_path
     /// to the current format.
     #[test]
     fn metadata_guard() {
-        let mut env = Env::new();
-        env.insert("SECRET_KEY_BASE", "abcdgoldfish");
-
         let target_id = TargetId::from_stack("heroku-22").unwrap();
         let metadata = Metadata {
             os_distribution: OsDistribution {

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -25,6 +25,9 @@ use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Command};
 
+// Latest metadata used for `TryMigrate` trait
+pub(crate) type Metadata = MetadataV4;
+
 pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     env: &Env,
@@ -74,8 +77,6 @@ pub(crate) fn call(
 
     layer_ref.read_env()
 }
-
-pub(crate) type Metadata = MetadataV4;
 
 // Introduced in https://github.com/heroku/buildpacks-ruby/pull/370
 // 2024-12-13

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -152,7 +152,7 @@ pub(crate) struct MetadataV4 {
     pub(crate) ruby_version: ResolvedRubyVersion,
 }
 
-fn clear_v1(_new: &Metadata, old: &Metadata) -> Vec<String> {
+fn clear_v1(_new: &MetadataV3, old: &MetadataV3) -> Vec<String> {
     if &old.force_bundle_install_key == "v1" {
         vec!["Internal gem directory structure changed".to_string()]
     } else {

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -216,7 +216,6 @@ impl TryFrom<MetadataV3> for MetadataV4 {
 }
 
 fn layer_env(layer_path: &Path, app_dir: &Path, without_default: &BundleWithout) -> LayerEnv {
-    // CAREFUL: See environment variable warning below vvvvvvvvvv
     let layer_env = LayerEnv::new()
         .chainable_insert(
             Scope::All,
@@ -249,11 +248,6 @@ fn layer_env(layer_path: &Path, app_dir: &Path, without_default: &BundleWithout)
             "BUNDLE_FROZEN", // Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
             "1",
         );
-    // CAREFUL: Changes to these ^^^^^^^ environment variables
-    //
-    // Not every run is guaranteed to trigger a `bundle_install`
-    // Rev the `force_bundle_install` cache key to ensure consistent
-    // state (when appropriate).
     layer_env
 }
 

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -53,7 +53,7 @@ pub(crate) fn call(
         launch: true,
     }
     .cached_layer(layer_name!("gems"), context, metadata)?;
-    let install_state = match &layer_ref.state {
+    let _ = match &layer_ref.state {
         LayerState::Restored { cause } => {
             print::sub_bullet(cause);
             match cause {
@@ -77,45 +77,22 @@ pub(crate) fn call(
         layer_env.apply(Scope::Build, env)
     };
 
-    match install_state {
-        InstallState::Run(reason) => {
-            if !reason.is_empty() {
-                print::sub_bullet(reason);
-            }
+    let mut cmd = Command::new("bundle");
+    cmd.arg("install")
+        .env_clear() // Current process env vars already merged into env
+        .envs(&env);
 
-            let mut cmd = Command::new("bundle");
-            cmd.arg("install")
-                .env_clear() // Current process env vars already merged into env
-                .envs(&env);
+    print::sub_stream_cmd(cmd.named_fn(|cmd| display_name(cmd, &env)))
+        .map_err(|error| fun_run::map_which_problem(error, cmd.mut_cmd(), env.get("PATH").cloned()))
+        .map_err(RubyBuildpackError::BundleInstallCommandError)?;
 
-            print::sub_stream_cmd(cmd.named_fn(|cmd| display_name(cmd, &env)))
-                .map_err(|error| {
-                    fun_run::map_which_problem(error, cmd.mut_cmd(), env.get("PATH").cloned())
-                })
-                .map_err(RubyBuildpackError::BundleInstallCommandError)?;
-
-            print::sub_time_cmd(
-                Command::new("bundle")
-                    .args(["clean", "--force"])
-                    .env_clear()
-                    .envs(&env),
-            )
-            .map_err(RubyBuildpackError::BundleInstallCommandError)?;
-        }
-        InstallState::Skip(checked) => {
-            let bundle_install = style::value("bundle install");
-            let help = style::important("HELP");
-
-            print::sub_bullet(format!(
-                "Skipping {bundle_install} (no changes found in {sources})",
-                sources = SentenceList::new(&checked).join_str("or")
-            ));
-            print::sub_bullet(format!(
-                "{help} To force run {bundle_install} set {}",
-                style::value(format!("{SKIP_DIGEST_ENV_KEY}=1"))
-            ));
-        }
-    }
+    print::sub_time_cmd(
+        Command::new("bundle")
+            .args(["clean", "--force"])
+            .env_clear()
+            .envs(&env),
+    )
+    .map_err(RubyBuildpackError::BundleInstallCommandError)?;
 
     layer_ref.read_env()
 }

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -3,12 +3,6 @@
 //! Creates the cache where gems live. We want 'bundle install'
 //! to execute on every build (as opposed to only when the cache is empty).
 //!
-//! As a small performance optimization, it will not run if the `Gemfile.lock`,
-//! `Gemfile`, or user provided "platform" environment variable have not changed.
-//! User applications can opt out of this behavior by setting the environment
-//! variable `HEROKU_SKIP_BUNDLE_DIGEST=1`. That would be useful if the application's
-//! `Gemfile` sources logic or data from another file that is unknown to the buildpack.
-//!
 //! Gems can be plain Ruby code which are OS, Architecture, and Ruby version independent.
 //! They can also be native extensions that use Ruby's C API or contain libraries that
 //! must be compiled and will then be invoked via FFI. These native extensions are

--- a/buildpacks/ruby/src/layers/ruby_install_layer.rs
+++ b/buildpacks/ruby/src/layers/ruby_install_layer.rs
@@ -31,6 +31,9 @@ use tar::Archive;
 use tempfile::NamedTempFile;
 use url::Url;
 
+// Latest metadata used for `TryMigrate` trait
+pub(crate) type Metadata = MetadataV3;
+
 pub(crate) fn call(
     context: &libcnb::build::BuildContext<RubyBuildpack>,
     metadata: &Metadata,
@@ -105,8 +108,6 @@ impl MetadataV3 {
         }
     }
 }
-
-pub(crate) type Metadata = MetadataV3;
 
 fn download_url(
     target: &TargetId,

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -276,7 +276,6 @@ pub(crate) enum RubyBuildpackError {
     MetricsAgentError(MetricsAgentInstallError),
     MissingGemfileLock(std::path::PathBuf, std::io::Error),
     InAppDirCacheError(CacheError),
-    BundleInstallDigestError(std::path::PathBuf, std::io::Error),
     BundleInstallCommandError(CmdError),
     RakeAssetsPrecompileFailed(CmdError),
     GemInstallBundlerCommandError(CmdError),

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -6,7 +6,6 @@
 use bullet_stream::{global::print, style};
 use commons::cache::CacheError;
 use commons::gemfile_lock::GemfileLock;
-use commons::metadata_digest::MetadataDigest;
 use core::str::FromStr;
 use fs_err::PathExt;
 use fun_run::CmdError;

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -207,21 +207,6 @@ impl Buildpack for RubyBuildpack {
                     },
                     cpu_architecture: context.target.arch.clone(),
                     ruby_version: ruby_version.clone(),
-                    force_bundle_install_key: String::from(
-                        crate::layers::bundle_install_layer::FORCE_BUNDLE_INSTALL_CACHE_KEY,
-                    ),
-                    digest: MetadataDigest::new_env_files(
-                        &context.platform,
-                        &[
-                            &context.app_dir.join("Gemfile"),
-                            &context.app_dir.join("Gemfile.lock"),
-                        ],
-                    )
-                    .map_err(|error| match error {
-                        commons::metadata_digest::DigestError::CannotReadFile(path, error) => {
-                            RubyBuildpackError::BundleInstallDigestError(path, error)
-                        }
-                    })?,
                 },
                 &BundleWithout::new("development:test"),
             )?;

--- a/buildpacks/ruby/src/target_id.rs
+++ b/buildpacks/ruby/src/target_id.rs
@@ -17,9 +17,6 @@ const DISTRO_VERSION_STACK: &[(&str, &str, &str)] = &[
 pub(crate) enum TargetIdError {
     #[error("Distro name and version '{0}-{1}' is not supported. Must be one of: {options}", options = DISTRO_VERSION_STACK.iter().map(|&(name, version, _)| format!("'{name}-{version}'")).collect::<Vec<_>>().join(", "))]
     UnknownDistroNameVersionCombo(String, String),
-
-    #[error("Cannot convert stack name '{0}' into a target OS. Must be one of: {options}", options = DISTRO_VERSION_STACK.iter().map(|&(_, _, stack)| format!("'{stack}'")).collect::<Vec<_>>().join(", "))]
-    UnknownStack(String),
 }
 
 impl TargetId {
@@ -38,18 +35,6 @@ impl TargetId {
                     self.distro_version.clone(),
                 )
             })
-    }
-
-    pub(crate) fn from_stack(stack_id: &str) -> Result<Self, TargetIdError> {
-        DISTRO_VERSION_STACK
-            .iter()
-            .find(|&&(_, _, stack)| stack == stack_id)
-            .map(|&(name, version, _)| TargetId {
-                cpu_architecture: String::from("amd64"),
-                distro_name: name.to_owned(),
-                distro_version: version.to_owned(),
-            })
-            .ok_or_else(|| TargetIdError::UnknownStack(stack_id.to_owned()))
     }
 }
 
@@ -98,27 +83,6 @@ mod test {
             }
             .stack_name()
             .unwrap()
-        );
-    }
-
-    #[test]
-    fn test_from_stack() {
-        assert_eq!(
-            TargetId::from_stack("heroku-22").unwrap(),
-            TargetId {
-                cpu_architecture: String::from("amd64"),
-                distro_name: String::from("ubuntu"),
-                distro_version: String::from("22.04"),
-            }
-        );
-
-        assert_eq!(
-            TargetId::from_stack("heroku-24").unwrap(),
-            TargetId {
-                cpu_architecture: String::from("amd64"),
-                distro_name: String::from("ubuntu"),
-                distro_version: String::from("24.04"),
-            }
         );
     }
 }

--- a/buildpacks/ruby/src/user_errors.rs
+++ b/buildpacks/ruby/src/user_errors.rs
@@ -185,34 +185,6 @@ fn log_our_error(error: RubyBuildpackError) {
                     Use the information above to debug further.
                 "});
         }
-        RubyBuildpackError::BundleInstallDigestError(path, error) => {
-            print::bullet(&debug_info);
-            print::sub_bullet(error.to_string());
-
-            if let Some(dir) = path.parent() {
-                print::bullet(format!(
-                    "{debug_info} Contents of the {} directory",
-                    style::value(dir.to_string_lossy())
-                ));
-                let _ =
-                    print::sub_stream_cmd(Command::new("ls").args(["-la", &dir.to_string_lossy()]));
-            }
-            print::error(formatdoc! {"
-                Error generating file digest
-
-                An error occurred while generating a file digest. To provide the fastest possible
-                install experience, the Ruby buildpack converts your `Gemfile` and `Gemfile.lock`
-                into a digest to use in cache invalidation.
-
-                Ensure that the permissions on the files in your application directory are correct and that
-                all symlinks correctly resolve.
-
-                If you're unable to resolve this error, you can disable the the digest feature by
-                setting the environment variable:
-
-                HEROKU_SKIP_BUNDLE_DIGEST=1
-            "});
-        }
         RubyBuildpackError::RakeDetectError(error) => {
             // Future:
             // - Annotate with information on requiring test or development only gems in the Rakefile

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -226,7 +226,6 @@ fn test_default_app_ubuntu24() {
 
         context.rebuild(config, |rebuild_context| {
             println!("{}", rebuild_context.pack_stderr);
-            assert_contains!(rebuild_context.pack_stderr, "Skipping `bundle install` (no changes found in /workspace/Gemfile, /workspace/Gemfile.lock, or user configured environment variables)");
             let rake_output = Regex::new(r"(?sm)START RAKE TEST OUTPUT\n(.*)END RAKE TEST OUTPUT").unwrap().captures(&rebuild_context.pack_stderr).and_then(|captures| captures.get(1).map(|m| m.as_str().to_string())).unwrap();
             assert_eq!(
                 r"
@@ -287,7 +286,6 @@ fn test_default_app_latest_distro() {
             let config = context.config.clone();
             context.rebuild(config, |rebuild_context| {
                 println!("{}", rebuild_context.pack_stderr);
-                assert_contains!(rebuild_context.pack_stderr, "Skipping `bundle install` (no changes found in /workspace/Gemfile, /workspace/Gemfile.lock, or user configured environment variables)");
 
                 rebuild_context.start_container(
                     ContainerConfig::new()

--- a/commons/CHANGELOG.md
+++ b/commons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for commons features
 
+## 2025-05-16
+
+### Changed
+
+- Deprecated `metadata_digest::MetadataDigest` with no replacement. If you depend on this logic please vendor it ([#425](https://github.com/heroku/buildpacks-ruby/pull/425))
+
 ## 2024-01-14
 
 ### Changed

--- a/commons/src/cache/app_cache.rs
+++ b/commons/src/cache/app_cache.rs
@@ -352,7 +352,7 @@ fn copy_mtime_r(from: &Path, to_path: &Path) -> Result<(), CacheError> {
 
         let mtime = entry
             .metadata()
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))
+            .map_err(std::io::Error::other)
             .map(|metadata| filetime::FileTime::from_last_modification_time(&metadata))
             .map_err(|error| CacheError::Mtime {
                 from: entry.path().to_path_buf(),

--- a/commons/src/metadata_digest.rs
+++ b/commons/src/metadata_digest.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use libcnb::{Env, Platform};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
@@ -151,6 +153,7 @@ const PLATFORM_ENV_VAR: &str = "user configured environment variables";
 /// above, but triggered by buildpack author instead of the end user.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
+#[deprecated(note = "The MetadataDigest struct and module are being removed")]
 pub struct MetadataDigest {
     platform_env: Option<PlatformEnvDigest>,
     files: Option<PathsDigest>, // Must be last for serde to be happy https://github.com/toml-rs/toml-rs/issues/142

--- a/docs/application_contract.md
+++ b/docs/application_contract.md
@@ -31,13 +31,7 @@ Once an application has passed the detect phase, the build phase will execute to
   - Given a `Gemfile.lock` with an explicit Bundler version we will install that bundler version.
   - Given a `Gemfile.lock` without an explicit Bundler version we will install a default Ruby version.
 - Ruby Dependencies:
-  - We MAY install gem dependencies using `bundle install`
-    - We will always run `bundle install` for the first build.
-    - We will sometimes run this command again if we detect one of the following has changed:
-      - `Gemfile`
-      - `Gemfile.lock`
-      - User configurable environment variables.
-    -To always run `bundle install` even if there are changes if the environment variable `HEROKU_SKIP_BUNDLE_DIGEST=1` is found.
+  - We will always run `bundle install`.
   - We will always run `bundle clean` after a successful `bundle install`.
   - We will always cache the contents of your gem dependencies.
       - We will always invalidate the dependency cache if your distribution name or version (operating system) changes.


### PR DESCRIPTION
Previously: We inspected the state of the last `Gemfile.lock` and user environment variables to only run `bundle install` when something changed. This provides minimal value in practice and requires a lot of plumbing. Now we call `bundle install` on every push. This adds a (relatively) negligible overhead (0.3~1s) per deploy for a fully cached app, and allows us to remove a lot of code.

- Deprecates `MetadataDigest` that was introduced to support this feature
- Removes old Metadata structs introduced before Fir went GA (details in commits)
- Removes logic used to support old metadata

Changes are structured in ordered commits with explanatory messages

GUS-W-18540827