### PR TITLE
Delete Rubygems cache directory

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `cache` directory that holds downloaded gems is now deleted after `bundle install`. This action reduces the final image size and does not impact future gem installation performance. ([#434](https://github.com/heroku/buildpacks-ruby/pull/434))
+
 ## [10.0.0] - 2025-06-02
 
 ### Changed

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -14,7 +14,6 @@ use bullet_stream::global::print;
 use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedRubyVersion;
 use commons::layer::diff_migrate::DiffMigrateLayer;
-use fs_err::PathExt;
 use fun_run::{self, CommandWithName};
 use indoc::formatdoc;
 use libcnb::data::layer_name;
@@ -77,14 +76,7 @@ pub(crate) fn call(
     )
     .map_err(RubyBuildpackError::BundleInstallCommandError)?;
 
-    let rubygems_cache = layer_ref.path().join("cache");
-    if let Err(error) = rubygems_cache.fs_err_try_exists().and_then(|exists| {
-        if exists {
-            fs_err::remove_dir_all(rubygems_cache)
-        } else {
-            Ok(())
-        }
-    }) {
+    if let Err(error) = fs_err::remove_dir_all(layer_ref.path().join("cache")) {
         print::sub_bullet(formatdoc! {"
             WARNING: Could not delete Rubygems cache directory
 

--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -14,7 +14,9 @@ use bullet_stream::global::print;
 use cache_diff::CacheDiff;
 use commons::gemfile_lock::ResolvedRubyVersion;
 use commons::layer::diff_migrate::DiffMigrateLayer;
+use fs_err::PathExt;
 use fun_run::{self, CommandWithName};
+use indoc::formatdoc;
 use libcnb::data::layer_name;
 use libcnb::layer::{EmptyLayerCause, LayerState};
 use libcnb::{
@@ -74,6 +76,27 @@ pub(crate) fn call(
             .envs(&env),
     )
     .map_err(RubyBuildpackError::BundleInstallCommandError)?;
+
+    let rubygems_cache = layer_ref.path().join("cache");
+    if let Err(error) = rubygems_cache.fs_err_try_exists().and_then(|exists| {
+        if exists {
+            fs_err::remove_dir_all(rubygems_cache)
+        } else {
+            Ok(())
+        }
+    }) {
+        print::sub_bullet(formatdoc! {"
+            WARNING: Could not delete Rubygems cache directory
+
+            This directory stores a copy of the original `<gem-name>.gem` files and is used for tasks such as
+            offline installs. The Ruby buildpack removes this directory as it's not used in a production
+            context, and deleting it reduces the final image size.
+
+            Your image will still be usable, but it might be larger due to this problem. For more information:
+
+            {error}
+        "});
+    }
 
     layer_ref.read_env()
 }

--- a/docs/application_contract.md
+++ b/docs/application_contract.md
@@ -38,6 +38,7 @@ Once an application has passed the detect phase, the build phase will execute to
       - We will always invalidate the dependency cache if your CPU architecture (i.e. amd64) changes.
       - We will always invalidate the dependency cache if your Ruby version changes.
       - We may invalidate the dependency cache if there was a bug in a prior buildpack version that needs to be fixed.
+  - We will delete the rubygems `cache` directory that holds the original `<gem-name>.gem` files after installation. This step reduces final image size and does not impact future `bundle install` installation performance.
 - Gem specific behavior - We will parse your `Gemfile.lock` to determine what dependencies your app need for use in specializing your install behavior (i.e. Rails 5 versus Rails 4). The inclusion of these gems may trigger different behavior:
   - `railties`
 - Applications without `rake` in the `Gemfile.lock` or a `Rakefile` variant MAY skip rake task detection.


### PR DESCRIPTION
Comparing output sizes between Classic and CNB showed that the CNB produces a larger disk size:

```
Classsic: 72M    vendor/bundle/ruby/3.2.0/gems
CNB:      100M    /layers/heroku_ruby/gems
```

Investigation showed this is due to the cache dir:

```
heroku@25c680a44a16:/workspace$ du -hs /layers/heroku_ruby/gems/* | sort -h -r
70M    /layers/heroku_ruby/gems/gems                # + 2M
17M    /layers/heroku_ruby/gems/extensions          # + 5M
13M    /layers/heroku_ruby/gems/cache               # + 13M
```

This is not present in the Classic buildpack as it's being manually removed https://github.com/heroku/heroku-buildpack-ruby/blob/471f5185cca999668fcc697120754ea9e03c9119/lib/language_pack/ruby.rb#L704-L705. We can perform the same optimization by deleting this directory.

## Verification


Before (568K cache dir):

```
$ git co main
$ cargo libcnb package
$ pack build my-image \
  --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_ruby \
  --trust-extra-buildpacks \
  --path buildpacks/ruby/tests/fixtures/default_ruby --clear-cache
$ docker run -it --rm --entrypoint='/cnb/lifecycle/launcher' my-image bash
heroku@ada0faae6840:/workspace$ du -hs /layers/heroku_ruby/gems/*
20K /layers/heroku_ruby/gems/bin
4.0K  /layers/heroku_ruby/gems/build_info
568K  /layers/heroku_ruby/gems/cache
4.0K  /layers/heroku_ruby/gems/doc
28K /layers/heroku_ruby/gems/env
464K  /layers/heroku_ruby/gems/extensions
3.0M  /layers/heroku_ruby/gems/gems
4.0K  /layers/heroku_ruby/gems/plugins
28K /layers/heroku_ruby/gems/specifications
```

After (no cache dir):

```
$ git co -
$ cargo libcnb package
$ pack build my-image \
  --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_ruby \
  --trust-extra-buildpacks \
  --path buildpacks/ruby/tests/fixtures/default_ruby --clear-cache
$ docker run -it --rm --entrypoint='/cnb/lifecycle/launcher' my-image bash
heroku@b07afddc44b6:/workspace$ du -hs /layers/heroku_ruby/gems/*
20K /layers/heroku_ruby/gems/bin
4.0K  /layers/heroku_ruby/gems/build_info
4.0K  /layers/heroku_ruby/gems/doc
28K /layers/heroku_ruby/gems/env
464K  /layers/heroku_ruby/gems/extensions
3.0M  /layers/heroku_ruby/gems/gems
4.0K  /layers/heroku_ruby/gems/plugins
28K /layers/heroku_ruby/gems/specifications
```

GUS-W-18528293