### PR TITLE
Configure Node CNB to skip pruning

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- When Node.js tooling is required, buildplan configuration is added to disable dev dependency pruning. ([#439](https://github.com/heroku/buildpacks-ruby/pull/439))
+
 ## [10.0.1] - 2025-06-09
 
 ### Fixed

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -80,14 +80,6 @@ impl Buildpack for RubyBuildpack {
                 .map_err(RubyBuildpackError::BuildpackDetectionError)?
             {
                 plan_builder = plan_builder.requires("node");
-
-                let mut node_configuration = Require::new("node_build_scripts");
-                node_configuration.metadata = toml! {
-                    // This needs to be disabled so that dev dependencies are available for
-                    // Ruby apps that need to perform asset compilation.
-                    skip_pruning = true
-                };
-                plan_builder = plan_builder.requires(node_configuration);
             }
 
             if context
@@ -98,6 +90,14 @@ impl Buildpack for RubyBuildpack {
                 .map_err(RubyBuildpackError::BuildpackDetectionError)?
             {
                 plan_builder = plan_builder.requires("yarn");
+
+                let mut node_configuration = Require::new("node_build_scripts");
+                node_configuration.metadata = toml! {
+                    // This needs to be disabled so that dev dependencies are available for
+                    // Ruby apps that need to perform asset compilation.
+                    skip_pruning = true
+                };
+                plan_builder = plan_builder.requires(node_configuration);
             }
 
             if fs_err::read_to_string(lockfile)

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -11,7 +11,7 @@ use fs_err::PathExt;
 use fun_run::CmdError;
 use layers::ruby_install_layer::RubyInstallError;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
-use libcnb::data::build_plan::BuildPlanBuilder;
+use libcnb::data::build_plan::{BuildPlanBuilder, Require};
 use libcnb::data::launch::LaunchBuilder;
 use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
@@ -33,7 +33,7 @@ mod user_errors;
 use libcnb_test as _;
 #[cfg(test)]
 use pretty_assertions as _;
-
+use toml::toml;
 use ureq as _;
 
 use crate::target_id::OsDistribution;
@@ -80,6 +80,14 @@ impl Buildpack for RubyBuildpack {
                 .map_err(RubyBuildpackError::BuildpackDetectionError)?
             {
                 plan_builder = plan_builder.requires("node");
+
+                let mut node_configuration = Require::new("node_build_scripts");
+                node_configuration.metadata = toml! {
+                    // This needs to be disabled so that dev dependencies are available for
+                    // Ruby apps that need to perform asset compilation.
+                    skip_pruning = true
+                };
+                plan_builder = plan_builder.requires(node_configuration);
             }
 
             if context

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -374,6 +374,7 @@ fn test_ruby_app_with_yarn_app() {
         ]),
         |context| {
             println!("{}", context.pack_stderr);
+            assert_contains!(context.pack_stderr, "pruning was disabled by a participating buildpack");
             assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
             assert_contains!(
                 context.pack_stderr,


### PR DESCRIPTION
The Node.js CNB is often used by the Ruby CNB to handle asset compilation for Rails apps. A recent change to the Node.js CNB made it so that dev dependencies are pruned at the end of its build phase, but these dev dependencies are then needed when the Ruby CNB wants to do asset compilation.

To support this use case, the Node.js CNB exposes a buildplan configuration that can control how some of these features work. This PR includes that required buildplan whenever Node.js tooling is required + modifies an integration test to verify that the configuration is working.

Closes https://github.com/heroku/buildpacks-nodejs/issues/1141