### PR TITLE
Fix clippy for Rust 1.89

### DIFF
--- a/buildpacks/ruby/src/layers/bundle_install_layer.rs
+++ b/buildpacks/ruby/src/layers/bundle_install_layer.rs
@@ -142,15 +142,13 @@ fn custom_cache_clear(_new: &MetadataV3, old: &MetadataV3) -> Vec<String> {
     changed
 }
 
-impl TryFrom<MetadataV3> for MetadataV4 {
-    type Error = std::convert::Infallible;
-
-    fn try_from(value: MetadataV3) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<MetadataV3> for MetadataV4 {
+    fn from(value: MetadataV3) -> Self {
+        Self {
             os_distribution: value.os_distribution,
             cpu_architecture: value.cpu_architecture,
             ruby_version: value.ruby_version,
-        })
+        }
     }
 }
 

--- a/buildpacks/ruby/tests/integration_test.rs
+++ b/buildpacks/ruby/tests/integration_test.rs
@@ -59,22 +59,22 @@ fn test_migrating_metadata_or_layer_names() {
             "docker://docker.io/heroku/buildpack-ruby:6.0.0".to_string(),
         )]),
         |context| {
-            println!("{}", context.pack_stderr);
+            println!("{}", context.pack_stdout);
             context.rebuild(
                 BuildConfig::new(builder, app_dir).buildpacks([BuildpackReference::CurrentCrate]),
                 |rebuild_context| {
-                    println!("{}", rebuild_context.pack_stderr);
+                    println!("{}", rebuild_context.pack_stdout);
 
                     assert_contains_match!(
-                        rebuild_context.pack_stderr,
+                        rebuild_context.pack_stdout,
                         r"^- Ruby version[^\n]*\n  - Using cache"
                     );
                     assert_contains_match!(
-                        rebuild_context.pack_stderr,
+                        rebuild_context.pack_stdout,
                         r"^- Bundler version[^\n]*\n  - Using cache"
                     );
                     assert_contains_match!(
-                        rebuild_context.pack_stderr,
+                        rebuild_context.pack_stdout,
                         r"^- Bundle install gems[^\n]*\n  - Using cache"
                     );
                 },
@@ -89,14 +89,14 @@ fn test_default_app_ubuntu22() {
     TestRunner::default().build(
         BuildConfig::new("heroku/builder:22", "tests/fixtures/default_ruby"),
         |context| {
-            println!("{}", context.pack_stderr);
-            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stdout);
+            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
 
-            assert_contains!(context.pack_stderr, "Installing puma");
+            assert_contains!(context.pack_stdout, "Installing puma");
         },
     );
 }
@@ -120,14 +120,14 @@ fn test_default_app_ubuntu24() {
     TestRunner::default().build(
         config.clone(),
         |context| {
-            println!("{}", context.pack_stderr);
-            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stdout);
+            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
 
-            assert_contains!(context.pack_stderr, "Installing puma");
+            assert_contains!(context.pack_stdout, "Installing puma");
 
         // Check that at run-time:
         // - The correct env vars are set.
@@ -225,8 +225,8 @@ fn test_default_app_ubuntu24() {
 
 
         context.rebuild(config, |rebuild_context| {
-            println!("{}", rebuild_context.pack_stderr);
-            let rake_output = Regex::new(r"(?sm)START RAKE TEST OUTPUT\n(.*)END RAKE TEST OUTPUT").unwrap().captures(&rebuild_context.pack_stderr).and_then(|captures| captures.get(1).map(|m| m.as_str().to_string())).unwrap();
+            println!("{}", rebuild_context.pack_stdout);
+            let rake_output = Regex::new(r"(?sm)START RAKE TEST OUTPUT\n(.*)END RAKE TEST OUTPUT").unwrap().captures(&rebuild_context.pack_stdout).and_then(|captures| captures.get(1).map(|m| m.as_str().to_string())).unwrap();
             assert_eq!(
                 r"
       $ echo $PATH
@@ -271,21 +271,21 @@ fn test_default_app_latest_distro() {
     TestRunner::default().build(
         config,
         |context| {
-            println!("{}", context.pack_stderr);
-            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stdout);
+            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
 
-            assert_contains!(context.pack_stderr, "Installing puma");
+            assert_contains!(context.pack_stdout, "Installing puma");
 
             let secret_key_base = context.run_shell_command("echo \"${SECRET_KEY_BASE:?No SECRET_KEY_BASE set}\"").stdout;
             assert!(!secret_key_base.trim().is_empty(), "Expected {secret_key_base:?} to not be empty but it is");
 
             let config = context.config.clone();
             context.rebuild(config, |rebuild_context| {
-                println!("{}", rebuild_context.pack_stderr);
+                println!("{}", rebuild_context.pack_stdout);
 
                 rebuild_context.start_container(
                     ContainerConfig::new()
@@ -352,13 +352,13 @@ DEPENDENCIES
             BuildpackReference::CurrentCrate,
         ]),
         |context| {
-            println!("{}", context.pack_stderr);
-            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stdout);
+            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
-            assert_contains!(context.pack_stderr, "Ruby version `3.1.4-jruby-9.4.8.0` from `Gemfile.lock`");
+            assert_contains!(context.pack_stdout, "Ruby version `3.1.4-jruby-9.4.8.0` from `Gemfile.lock`");
             });
 }
 
@@ -373,11 +373,11 @@ fn test_ruby_app_with_yarn_app() {
             BuildpackReference::CurrentCrate,
         ]),
         |context| {
-            println!("{}", context.pack_stderr);
-            assert_contains!(context.pack_stderr, "pruning was disabled by a participating buildpack");
-            assert_contains!(context.pack_stderr, "# Heroku Ruby Buildpack");
+            println!("{}", context.pack_stdout);
+            assert_contains!(context.pack_stdout, "pruning was disabled by a participating buildpack");
+            assert_contains!(context.pack_stdout, "# Heroku Ruby Buildpack");
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 r#"`BUNDLE_FROZEN="1" BUNDLE_GEMFILE="/workspace/Gemfile" BUNDLE_WITHOUT="development:test" bundle install`"#
             );
             }

--- a/commons/src/layer/fixtures/metadata_migration_example.md
+++ b/commons/src/layer/fixtures/metadata_migration_example.md
@@ -1,4 +1,4 @@
- ## Setup DiffMigrateLayer for new layer Metadata
+ ## Setup `DiffMigrateLayer` for new layer Metadata
 
 Starting from scratch, add dependencies:
 
@@ -105,7 +105,7 @@ The signature
 
 - Defines a `call` function that:
   - Takes a build context. In your code you'll want to replace the generic with a concrete buildpack type.
-  - Takes a bullet_stream printer for maximal printing consistency
+  - Takes a `bullet_stream` printer for maximal printing consistency
   - A `Metadata` struct constructed externally
 
 The logic of the function uses [`DiffMigrateLayer`] to create a layer that is both available at build and launch time. It creates a layer named "ruby" and passes in our metadata. When this executes it will:


### PR DESCRIPTION
```
 error: item in documentation is missing backticks
 --> commons/src/layer/fixtures/metadata_migration_example.md:1:11
  |
1 |  ## Setup DiffMigrateLayer for new layer Metadata
  |           ^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
  = note: `-D clippy::doc-markdown` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::doc_markdown)]`
help: try
  |
1 -  ## Setup DiffMigrateLayer for new layer Metadata
1 +  ## Setup `DiffMigrateLayer` for new layer Metadata
  |

    Checking libcnb-test v0.29.0
error: item in documentation is missing backticks
   --> commons/src/layer/fixtures/metadata_migration_example.md:108:13
    |
108 |   - Takes a bullet_stream printer for maximal printing consistency
    |             ^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
help: try
    |
108 -   - Takes a bullet_stream printer for maximal printing consistency
108 +   - Takes a `bullet_stream` printer for maximal printing consistency
    |

error: could not compile `commons` (lib) due to 2 previous errors
```

```
warning: infallible TryFrom impl; consider implementing From, instead
   --> buildpacks/ruby/src/layers/bundle_install_layer.rs:145:1
    |
145 | impl TryFrom<MetadataV3> for MetadataV4 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
146 |     type Error = std::convert::Infallible;
    |                  ------------------------ infallible error type
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#infallible_try_from
    = note: `#[warn(clippy::infallible_try_from)]` on by default
```

Close #448

GUS-W-19345402
