### PR TITLE
Sync default bundler verison with Classic buildpack

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default bundler version is now 2.3.27
+
 ## [12.2.0] - 2025-12-02
 
 ### Added

--- a/buildpacks/ruby/src/main.rs
+++ b/buildpacks/ruby/src/main.rs
@@ -134,7 +134,7 @@ impl Buildpack for RubyBuildpack {
         let lockfile_contents = fs_err::read_to_string(&lockfile)
             .map_err(|error| RubyBuildpackError::MissingGemfileLock(lockfile, error))?;
         let gemfile_lock = GemfileLock::from_str(&lockfile_contents).expect("Infallible");
-        let bundler_version = gemfile_lock.resolve_bundler("2.5.23");
+        let bundler_version = gemfile_lock.resolve_bundler("2.3.27");
         let ruby_version = gemfile_lock.resolve_ruby("3.3.9");
         tracing::info!(
             // Bundler version the app is asking for i.e. "2.6.7"


### PR DESCRIPTION
The CNB supports only heroku-24+ while the classic supports heroku-22+. Decreasing the default bundler version on the CNB allows us to align both buildpacks to the same bundler version.

Note that this will only take effect if the default bundler version that ships with Ruby is less than the default version we supply.

GUS-W-21093069