### PR TITLE
Correct the v12.4.1 release date to 2026-07-08

### DIFF
--- a/buildpacks/ruby/CHANGELOG.md
+++ b/buildpacks/ruby/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [12.4.1] - 2026-07-07
+## [12.4.1] - 2026-07-08
 
 ### Changed
 


### PR DESCRIPTION
The release was published on 2026-07-08, not 2026-07-07 — it was delayed by the release-automation issue (heroku/languages-github-actions#383). Correct the CHANGELOG entry date to match.